### PR TITLE
Support for $HOME

### DIFF
--- a/newdc/linux-dist/main.cpp
+++ b/newdc/linux-dist/main.cpp
@@ -454,7 +454,19 @@ int main(int argc, wchar* argv[])
 		//ndcid=atoi(argv[1]);
 
 	if (setup_curses() < 0) die("failed to setup curses!\n");
+#if defined(USES_HOMEDIR)
+	string home = (string)getenv("HOME");
+	if(home.c_str())
+	{
+		home += "/.reicast";
+		mkdir(home.c_str(), 0755); // create the directory if missing
+		SetHomeDir(home);
+	}
+	else
+		SetHomeDir(".");
+#else
 	SetHomeDir(".");
+#endif
 
 	printf("Home dir is: %s\n",GetPath("/").c_str());
 

--- a/reicast/gcwz/Makefile
+++ b/reicast/gcwz/Makefile
@@ -30,7 +30,7 @@ SOURCES	:=	cfg/ hw/arm7/ hw/aica/ hw/asic/ hw/ hw/gdrom/ hw/maple/ \
  hw/extdev/ hw/arm/ imgread/ linux/ linux-dist/ ./ rec-ARM/ deps/zlib/ deps/chdr/ deps/crypto/ arm_emitter/ 
 
 
-CXXFLAGS := -g -O3  -D RELEASE -c -D TARGET_GCW0 -D HOST_NO_REC #-D NO_REND
+CXXFLAGS := -g -O3  -D RELEASE -c -D TARGET_GCW0 -D USES_HOMEDIR -D HOST_NO_REC #-D NO_REND
 CXXFLAGS += -frename-registers -fno-strict-aliasing -fsingle-precision-constant 
 CXXFLAGS += -ffast-math -ftree-vectorize 
 #-fprefetch-loop-arrays 


### PR DESCRIPTION
This change retrieves the content of $HOME environment variable, creates a directory $HOME/.reicast (if missing) and then sets this path as SetHomeDir().
