### PR TITLE
Update small warning in core.mk

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -54,5 +54,6 @@ RZDCY_CXXFLAGS	:= \
 	-D_ANDROID -DRELEASE -DTARGET_BEAGLE\
 	-march=armv7-a -mtune=cortex-a9 -mfpu=vfpv3-d16 -mfloat-abi=softfp \
 	-frename-registers -fsingle-precision-constant -ffast-math \
-	-ftree-vectorize -fomit-frame-pointer -fno-exceptions -fno-rtti -std=gnu++11
+	-ftree-vectorize -fomit-frame-pointer 
+LOCAL_CPPFLAGS := -fno-exceptions -std=gnu++11 -fno-rtti
 endif


### PR DESCRIPTION
define fix warning flags 
i.e warning: command line option '-std=gnu++11' is valid for C++/ObjC++ but not for C .
