### PR TITLE
Update game selection to prevent launching BIOS for all

### DIFF
--- a/shell/android/src/com/reicast/emulator/FileBrowser.java
+++ b/shell/android/src/com/reicast/emulator/FileBrowser.java
@@ -324,20 +324,17 @@ public class FileBrowser extends Fragment {
 			childview.setTag(list.get(i));
 
 			orig_bg = childview.getBackground();
+			
+			final File game = list.get(i);
 
 			// vw.findViewById(R.id.childview).setBackgroundColor(0xFFFFFFFF);
 
 			childview.findViewById(R.id.childview).setOnClickListener(
 					new OnClickListener() {
 						public void onClick(View view) {
-							File f = (File) view.getTag();
 							vib.vibrate(50);
-							mCallback.onGameSelected(f != null ? Uri
-									.fromFile(f) : Uri.EMPTY);
-							// Intent inte = new
-							// Intent(Intent.ACTION_VIEW,f!=null?
-							// Uri.fromFile(f):Uri.EMPTY,parentActivity.getBaseContext(),GL2JNIActivity.class);
-							// FileBrowser.this.startActivity(inte);
+							mCallback.onGameSelected(game != null ? Uri
+									.fromFile(game) : Uri.EMPTY);
 							vib.vibrate(250);
 						}
 					});


### PR DESCRIPTION
Seems this caught the issue the folders were having. I tried new File(whatever.getTag()) to see if it was a cast issue and it didn't change the outcome. The BIOS is still set with the (File) cast, but that is technically null anyway so it doesn't really matter how it ends up a file.
