### PR TITLE
Fix wrong value being returned in InitDrive in imgread/common.cpp

### DIFF
--- a/core/imgread/common.cpp
+++ b/core/imgread/common.cpp
@@ -182,7 +182,7 @@ bool InitDrive(u32 fileflags)
 	if (!InitDrive_(fn))
 	{
 		//msgboxf("Selected image failed to load",MBX_ICONERROR);
-		return true;
+		return false;
 	}
 	else
 	{


### PR DESCRIPTION
If initialization fails, true obviously shouldn't be returned.
