### PR TITLE
Revert to off-site test repository as default about sourcing

### DIFF
--- a/shell/android/res/values/strings.xml
+++ b/shell/android/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="moga_connect">MOGA Connected!</string>
 
     <string name="about_text">reicast is a dreamcast emulator\n\nVersion: %1$s</string>
-    <string name="git_api">https://api.github.com/repos/reicast/reicast-emulator/commits</string>
+    <string name="git_api">https://api.github.com/repos/NoblesseOblige/reicast-emulator/commits</string>
     
     <string-array name="controllers">
     <item>Controller A</item>


### PR DESCRIPTION
To have the change log properly track the android branch, it either
needs to be configured as the default branch, or the api URL has to use
the general project activity format which will lead to extreme excess
parsing and formatting time.

To avoid these issues, the androidui branch is set to default at this
repository and the commits mirror the reicast repo.
