### PR TITLE
Update strings.xml

### DIFF
--- a/shell/android/res/values/strings.xml
+++ b/shell/android/res/values/strings.xml
@@ -84,7 +84,7 @@
     
     <string-array name="region">
         <item>Japanese, Korean, Asian - (NTSC-J)</item>
-        <item>North American, Brazilian, Argentine - (NTSC-U/PAL-M/PAL-M)</item>
+        <item>North American, Brazilian, Argentine - (NTSC-U/PAL-M/PAL-N)</item>
         <item>European - (PAL-E)</item>
         <item>R - Region Free</item>
     </string-array>


### PR DESCRIPTION
Switch American & Japanese around to assign correct region values.
00 = Japanese NTSC
01 = American NTSC/PAL

Broadcast value is always wrongly set to 04.

00 Japan (NTSC)
04 North America (NTSC), 06 Brazil (PAL-M), 07 Argentina (PAL-N)
09 Europe (PAL)
