### PR TITLE
Fixed start button mapping for PS3 controller.

### DIFF
--- a/shell/android/src/com/reicast/emulator/emu/GL2JNIActivity.java
+++ b/shell/android/src/com/reicast/emulator/emu/GL2JNIActivity.java
@@ -172,7 +172,7 @@ public class GL2JNIActivity extends Activity {
 									OuyaController.BUTTON_DPAD_LEFT, key_CONT_DPAD_LEFT,
 									OuyaController.BUTTON_DPAD_RIGHT, key_CONT_DPAD_RIGHT,
 
-									OuyaController.BUTTON_R1, key_CONT_START
+									KeyEvent.KEYCODE_BUTTON_START, key_CONT_START
 
 							};
 						} else if (InputDevice.getDevice(joys[i]).getName()


### PR DESCRIPTION
The start button  was mapped to R1, this change works fine with my Nexus 7.

The X-Box controller seems to have the same problem but I don't have one of those to test with.
