### PR TITLE
Move right stick toggle to options, Remove "exit" buttons

### DIFF
--- a/shell/android/res/layout/input_mod_fragment.xml
+++ b/shell/android/res/layout/input_mod_fragment.xml
@@ -93,6 +93,34 @@
                     android:layout_weight="0.5"
                     android:ems="10"
                     android:gravity="center_vertical|left"
+                    android:text="@string/rstick_mode" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="right"
+                    android:orientation="vertical" >
+
+                    <de.ankri.views.Switch
+                        android:id="@+id/switchRightStickLREnabled"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:focusable="true" />
+                </LinearLayout>
+            </TableRow>
+            
+            
+            <TableRow
+                android:layout_marginTop="25dp"
+                android:gravity="center_vertical" >
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.5"
+                    android:ems="10"
+                    android:gravity="center_vertical|left"
                     android:text="@string/joystick_layout" />
 
                 <LinearLayout

--- a/shell/android/res/values/strings.xml
+++ b/shell/android/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="select_controller_title">Select Controller</string>
     <string name="select_controller_message">Press any button on the controller %1$s to assign to port</string>
     <string name="controller_already_in_use">This controller is already in use!</string>
+    <string name="rstick_mode">Right Stick: On - L/R, Off - A/B</string>
     <string name="joystick_layout">Use Joystick For D-Pad Input</string>
     <string name="modified_layout">Enable Custom Key Layout</string>
     <string name="controller_compat">Enable Compatibility Mode</string>

--- a/shell/android/src/com/reicast/emulator/GL2JNIActivity.java
+++ b/shell/android/src/com/reicast/emulator/GL2JNIActivity.java
@@ -277,7 +277,7 @@ public class GL2JNIActivity extends Activity {
 					GL2JNIView.lt[playerNum] = (int) (L2 * 255);
 					GL2JNIView.rt[playerNum] = (int) (R2 * 255);
 
-					if (prefs.getBoolean("right_buttons", true)) {
+					if (prefs.getBoolean(Gamepad.pref_js_rbuttons + pad.portId[playerNum], true)) {
 						if (RS_Y > 0.25) {
 							handle_key(playerNum, pad.map[playerNum][0]/* A */, true);
 							pad.wasKeyStick[playerNum] = true;

--- a/shell/android/src/com/reicast/emulator/GL2JNINative.java
+++ b/shell/android/src/com/reicast/emulator/GL2JNINative.java
@@ -367,7 +367,7 @@ public class GL2JNINative extends NativeActivity {
 					GL2JNIView.lt[playerNum] = (int) (L2 * 255);
 					GL2JNIView.rt[playerNum] = (int) (R2 * 255);
 
-					if (prefs.getBoolean("right_buttons", true)) {
+					if (prefs.getBoolean(Gamepad.pref_js_rbuttons + pad.portId[playerNum], true)) {
 						if (RS_Y > 0.25) {
 							handle_key(playerNum, pad.map[playerNum][0]/* A */, true);
 							pad.wasKeyStick[playerNum] = true;

--- a/shell/android/src/com/reicast/emulator/config/InputModFragment.java
+++ b/shell/android/src/com/reicast/emulator/config/InputModFragment.java
@@ -44,6 +44,7 @@ public class InputModFragment extends Fragment {
 	private SharedPreferences mPrefs;
 
 	private Switch switchJoystickDpadEnabled;
+	private Switch switchRightStickLREnabled;
 	private Switch switchModifiedLayoutEnabled;
 	private Switch switchCompatibilityEnabled;
 
@@ -96,6 +97,8 @@ public class InputModFragment extends Fragment {
 		
 		switchJoystickDpadEnabled = (Switch) getView().findViewById(
 				R.id.switchJoystickDpadEnabled);
+		switchRightStickLREnabled = (Switch) getView().findViewById(
+				R.id.switchRightStickLREnabled);
 		switchModifiedLayoutEnabled = (Switch) getView().findViewById(
 				R.id.switchModifiedLayoutEnabled);
 		switchCompatibilityEnabled = (Switch) getView().findViewById(
@@ -111,6 +114,17 @@ public class InputModFragment extends Fragment {
 		};
 		
 		switchJoystickDpadEnabled.setOnCheckedChangeListener(joystick_mode);
+		
+		OnCheckedChangeListener rstick_mode = new OnCheckedChangeListener() {
+			public void onCheckedChanged(CompoundButton buttonView,
+					boolean isChecked) {
+				mPrefs.edit()
+						.putBoolean(Gamepad.pref_js_rbuttons + player,
+								isChecked).commit();
+			}
+		};
+		
+		switchRightStickLREnabled.setOnCheckedChangeListener(rstick_mode);
 
 		OnCheckedChangeListener modified_layout = new OnCheckedChangeListener() {
 			public void onCheckedChanged(CompoundButton buttonView,

--- a/shell/android/src/com/reicast/emulator/emu/OnScreenMenu.java
+++ b/shell/android/src/com/reicast/emulator/emu/OnScreenMenu.java
@@ -25,7 +25,6 @@ import com.reicast.emulator.GL2JNINative;
 import com.reicast.emulator.MainActivity;
 import com.reicast.emulator.R;
 import com.reicast.emulator.config.Config;
-import com.reicast.emulator.periph.Gamepad;
 import com.reicast.emulator.periph.VmuLcd;
 
 public class OnScreenMenu {
@@ -166,12 +165,12 @@ public class OnScreenMenu {
 				}
 			}), debugParams);
 
-			hlay.addView(addbut(R.drawable.close, "Exit", new OnClickListener() {
-				public void onClick(View v) {
-					popups.remove(DebugPopup.this);
-					dismiss();
-				}
-			}), debugParams);
+//			hlay.addView(addbut(R.drawable.close, "Exit", new OnClickListener() {
+//				public void onClick(View v) {
+//					popups.remove(DebugPopup.this);
+//					dismiss();
+//				}
+//			}), debugParams);
 
 			setContentView(hlay);
 			popups.add(this);
@@ -190,7 +189,6 @@ public class OnScreenMenu {
 
 	public class ConfigPopup extends PopupWindow {
 
-		private View rsticksetting;
 		private View fullscreen;
 		private View framelimit;
 		private View audiosetting;
@@ -217,29 +215,6 @@ public class OnScreenMenu {
 			});
 			hlay.addView(up, configParams);
 			menuItems.add(up);
-			
-			rsticksetting = addbut(R.drawable.toggle_a_b, "Right Stick", 
-					new OnClickListener() {
-						public void onClick(View v) {
-							if (prefs
-									.getBoolean(Gamepad.pref_js_rbuttons, true)) {
-								prefs.edit()
-										.putBoolean(Gamepad.pref_js_rbuttons,
-												false).commit();
-								modbut(rsticksetting, R.drawable.toggle_a_b);
-							} else {
-								prefs.edit()
-										.putBoolean(Gamepad.pref_js_rbuttons,
-												true).commit();
-								modbut(rsticksetting, R.drawable.toggle_r_l);
-							}
-							dismiss();
-						}
-					});
-			if (prefs.getBoolean(Gamepad.pref_js_rbuttons, true)) {
-				modbut(rsticksetting, R.drawable.toggle_r_l);
-			}
-			hlay.addView(rsticksetting, params);
 
 			fullscreen = addbut(R.drawable.widescreen, "Widescreen", new OnClickListener() {
 				public void onClick(View v) {
@@ -401,14 +376,14 @@ public class OnScreenMenu {
 			hlay.addView(fastforward, params);
 			menuItems.add(fastforward);
 
-			View close = addbut(R.drawable.close, "Exit", new OnClickListener() {
-				public void onClick(View v) {
-					popups.remove(ConfigPopup.this);
-					dismiss();
-				}
-			});
-			hlay.addView(close, configParams);
-			menuItems.add(close);
+//			View close = addbut(R.drawable.close, "Exit", new OnClickListener() {
+//				public void onClick(View v) {
+//					popups.remove(ConfigPopup.this);
+//					dismiss();
+//				}
+//			});
+//			hlay.addView(close, configParams);
+//			menuItems.add(close);
 
 			setContentView(hlay);
 			getFocusedItem();


### PR DESCRIPTION
Going back to the previous menu to exit isn't a huge inconvenience.
The right stick setting was not in options, but doesn't require a dynamic setting.
