### PR TITLE
BIOS Locator and fixes for KitKat Samsung directories

### DIFF
--- a/shell/android/src/com/reicast/emulator/MainActivity.java
+++ b/shell/android/src/com/reicast/emulator/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends SlidingFragmentActivity implements
 
 	private SharedPreferences mPrefs;
 	private static File sdcard = Environment.getExternalStorageDirectory();
-	public static String home_directory = sdcard + "/dc";
+	public static String home_directory = sdcard.getAbsolutePath();
 
 	private TextView menuHeading;
 	private boolean hasAndroidMarket = false;

--- a/shell/android/src/com/reicast/emulator/config/OptionsFragment.java
+++ b/shell/android/src/com/reicast/emulator/config/OptionsFragment.java
@@ -50,8 +50,8 @@ public class OptionsFragment extends Fragment {
 
 	private SharedPreferences mPrefs;
 	private File sdcard = Environment.getExternalStorageDirectory();
-	private String home_directory = sdcard + "/dc";
-	private String game_directory = sdcard + "/dc";
+	private String home_directory = sdcard.getAbsolutePath();
+	private String game_directory = sdcard.getAbsolutePath();
 	
 	private String[] codes;
 
@@ -91,10 +91,9 @@ public class OptionsFragment extends Fragment {
 		HashSet<String> extStorage = FileBrowser.getExternalMounts();
 		if (extStorage != null && !extStorage.isEmpty()) {
 			for (Iterator<String> sd = extStorage.iterator(); sd.hasNext();) {
-				String sdCardPath = sd.next();
-				if (!sdCardPath.equals(sdcard)) {
-//					home_directory = sdCardPath + "/dc";
-					game_directory = sdCardPath + "/dc";
+				String sdCardPath = sd.next().replace("mnt/media_rw", "storage");
+				if (!sdCardPath.equals(sdcard.getAbsolutePath())) {
+					game_directory = sdCardPath;
 				}
 			}
 		}


### PR DESCRIPTION
This resolves locating the external storage on KitKat Samsung devices by locating their specialty "extSdCard" folder by the accessible path. Tested against a Note 4 without any external storage patches for permission.
