### PR TITLE
No debug plugin means no need for a sharedId

### DIFF
--- a/shell/android/AndroidManifest.xml
+++ b/shell/android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reicast.emulator"
-    android:sharedUserId="android.uid.reicast"
     android:versionCode="6"
     android:versionName="0.r6" >
 


### PR DESCRIPTION
May also resolve some issues with installing over an existing build
without uninstalling the build first.
