### PR TITLE
http support for cdi & gdi, updated based gdipsr

### DIFF
--- a/core/deps/chdpsr/cdipsr.cpp
+++ b/core/deps/chdpsr/cdipsr.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include "deps/coreio/coreio.h"
 #include "cdipsr.h"
 
 // Global variables
@@ -11,6 +12,10 @@ unsigned long temp_value;
 
 /////////////////////////////////////////////////////////////////////////////
 
+#define FILE core_file
+#define fread(buff,sz,cnt,fc) core_fread(fc,buff,sz*cnt)
+#define fseek core_fseek
+#define ftell core_ftell
 
 unsigned long ask_type(FILE *fsource, long header_position)
 {
@@ -110,8 +115,7 @@ void CDI_get_tracks (FILE *fsource, image_s *image)
 
 void CDI_init (FILE *fsource, image_s *image, char *fsourcename)
 {
-     fseek(fsource, 0L, SEEK_END);
-     image->length = ftell(fsource);
+	image->length = core_fsize(fsource);
 
      if (image->length < 8) printf( "Image file is too short");
 

--- a/core/deps/chdpsr/cdipsr.h
+++ b/core/deps/chdpsr/cdipsr.h
@@ -1,7 +1,7 @@
 #ifndef __CDI_H__
 #define __CDI_H__
 
-
+#include "deps/coreio/coreio.h"
 
 /* Basic structures */
 
@@ -38,12 +38,11 @@ typedef struct track_s
 #define CDI_V3  0x80000005
 #define CDI_V35 0x80000006
 
-unsigned long ask_type(FILE *fsource, long header_position);
-void CDI_init (FILE *fsource, image_s *image, char *fsourcename);
-void CDI_get_sessions (FILE *fsource, image_s *image);
-void CDI_get_tracks (FILE *fsource, image_s *image);
-void CDI_read_track (FILE *fsource, image_s *image, track_s *track);
-void CDI_skip_next_session (FILE *fsource, image_s *image);
+unsigned long ask_type(core_file *fsource, long header_position);
+void CDI_init(core_file *fsource, image_s *image, char *fsourcename);
+void CDI_get_sessions(core_file *fsource, image_s *image);
+void CDI_get_tracks(core_file *fsource, image_s *image);
+void CDI_read_track(core_file *fsource, image_s *image, track_s *track);
+void CDI_skip_next_session(core_file *fsource, image_s *image);
 
 #endif
-

--- a/core/deps/coreio/coreio.cpp
+++ b/core/deps/coreio/coreio.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <iomanip>
+#include <cctype>
 
 #define TRUE 1
 #define FALSE 0

--- a/core/deps/coreio/coreio.cpp
+++ b/core/deps/coreio/coreio.cpp
@@ -5,6 +5,10 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sstream>
+#include <string>
+#include <iomanip>
+
 #define TRUE 1
 #define FALSE 0
 
@@ -21,6 +25,27 @@
 	#include <netdb.h>
 	#include <unistd.h>
 #endif
+
+string url_encode(const string &value) {
+	ostringstream escaped;
+	escaped.fill('0');
+	escaped << hex;
+
+	for (string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
+		string::value_type c = (*i);
+
+		// Keep alphanumeric and other accepted characters intact
+		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~' || c  == '/' || c =='%' ) {
+			escaped << c;
+			continue;
+		}
+
+		// Any other characters are percent-encoded
+		escaped << '%' << setw(2) << int((unsigned char)c);
+	}
+
+	return escaped.str();
+}
 
 size_t HTTP_GET(string host, int port,string path, size_t offs, size_t len, void* pdata){
     string request;
@@ -97,7 +122,7 @@ size_t HTTP_GET(string host, int port,string path, size_t offs, size_t len, void
 	*/
 	size_t content_length = 0;
 	
-	size_t rv = content_length;
+	size_t rv = 0;
 
 	for (;;) {
 		stringstream ss;
@@ -128,10 +153,10 @@ size_t HTTP_GET(string host, int port,string path, size_t offs, size_t len, void
 _data:
 
 	if (len == 0) {
-
+		rv = content_length;
 	}
 	else {
-		verify(len == content_length);
+		verify(len == content_length); //crash is a bit too harsh here perhaps?
 		u8* ptr = (u8*)pdata;
 		do
 		{
@@ -141,6 +166,8 @@ _data:
 			ptr += rcv;
 		}
 		while (len >0);
+
+		rv = content_length;
 	}
 
 	_cleanup:
@@ -180,7 +207,7 @@ core_file* core_fopen(const char* filename)
 		rv->host = p.substr(7,p.npos);
 		rv->host = rv->host.substr(0, rv->host.find_first_of("/"));
 
-		rv->path = p.substr(p.find("/", 7), p.npos);
+		rv->path = url_encode(p.substr(p.find("/", 7), p.npos));
 		
 		rv->port = 80;
 		size_t pos = rv->host.find_first_of(":");
@@ -198,6 +225,7 @@ core_file* core_fopen(const char* filename)
 		}
 	}
 
+	core_fseek((core_file*)rv, 0, SEEK_SET);
 	return (core_file*)rv;
 }
 
@@ -217,6 +245,10 @@ size_t core_fseek(core_file* fc, size_t offs, size_t origin) {
 	return 0;
 }
 
+size_t core_ftell(core_file* fc) {
+	CORE_FILE* f = (CORE_FILE*)fc;
+	return f->seek_ptr;
+}
 int core_fread(core_file* fc, void* buff, size_t len)
 {
 	CORE_FILE* f = (CORE_FILE*)fc;

--- a/core/deps/coreio/coreio.h
+++ b/core/deps/coreio/coreio.h
@@ -10,3 +10,4 @@ size_t core_fseek(core_file* fc, size_t offs, size_t origin);
 int core_fread(core_file* fc, void* buff, size_t len);
 int core_fclose(core_file* fc);
 size_t core_fsize(core_file* fc);
+size_t core_ftell(core_file* fc);

--- a/core/imgread/cdi.cpp
+++ b/core/imgread/cdi.cpp
@@ -8,7 +8,7 @@
 
 Disc* cdi_parse(const wchar* file)
 {
-	FILE* fsource=fopen(file,"rb");
+	core_file* fsource=core_fopen(file);
 
 	if (!fsource)
 		return 0;
@@ -34,7 +34,7 @@ Disc* cdi_parse(const wchar* file)
 
 		CDI_get_tracks (fsource, &image);
 
-		image.header_position = ftell(fsource);
+		image.header_position = core_ftell(fsource);
 
 		printf("\nSession %d has %d track(s)\n",image.global_current_session,image.tracks);
 
@@ -54,7 +54,7 @@ Disc* cdi_parse(const wchar* file)
 
 				CDI_read_track (fsource, &image, &track);
 
-				image.header_position = ftell(fsource);
+				image.header_position = core_ftell(fsource);
 
 				// Show info
 
@@ -98,7 +98,7 @@ Disc* cdi_parse(const wchar* file)
 				t.CTRL=track.mode==0?0:4;
 				t.StartFAD=track.start_lba+track.pregap_length;
 				t.EndFAD=t.StartFAD+track.length-1;
-				t.file = new RawTrackFile(fopen(file,"rb"),track.position + track.pregap_length * track.sector_size,t.StartFAD,track.sector_size);
+				t.file = new RawTrackFile(core_fopen(file),track.position + track.pregap_length * track.sector_size,t.StartFAD,track.sector_size);
 
 				rv->tracks.push_back(t);
 
@@ -115,21 +115,21 @@ Disc* cdi_parse(const wchar* file)
 					if (track.total_length < track.length + track.pregap_length)
 					{
 						printf("\nThis track seems truncated. Skipping...\n");
-						fseek(fsource, track.position, SEEK_SET);
-						fseek(fsource, track.total_length, SEEK_CUR);
-						track.position = ftell(fsource);
+						core_fseek(fsource, track.position, SEEK_SET);
+						core_fseek(fsource, track.total_length, SEEK_CUR);
+						track.position = core_ftell(fsource);
 					}
 					else
 					{
 						
 						printf("Track position: %d\n",track.position + track.pregap_length * track.sector_size);
-						fseek(fsource, track.position, SEEK_SET);
+						core_fseek(fsource, track.position, SEEK_SET);
 						//     fseek(fsource, track->pregap_length * track->sector_size, SEEK_CUR);
 						//     fseek(fsource, track->length * track->sector_size, SEEK_CUR);
-						fseek(fsource, track.total_length * track.sector_size, SEEK_CUR);
+						core_fseek(fsource, track.total_length * track.sector_size, SEEK_CUR);
 
 						//savetrack(fsource, &image, &track, &opts, &flags);
-						track.position = ftell(fsource);
+						track.position = core_ftell(fsource);
 
 						rv->EndFAD=track.start_lba +track.total_length;
 						// Generate cuesheet entries
@@ -140,7 +140,7 @@ Disc* cdi_parse(const wchar* file)
 					}
 				}
 
-				fseek(fsource, image.header_position, SEEK_SET);
+				core_fseek(fsource, image.header_position, SEEK_SET);
 
 
 				// Close loops

--- a/core/imgread/common.h
+++ b/core/imgread/common.h
@@ -3,6 +3,8 @@
 #include <vector>
 using namespace std;
 
+#include "deps/coreio/coreio.h"
+
 extern u32 NullDriveDiscType;
 struct TocTrackInfo
 {
@@ -261,12 +263,12 @@ Disc* OpenDisc(const wchar* fn);
 
 struct RawTrackFile : TrackFile
 {
-	FILE* file;
+	core_file* file;
 	s32 offset;
 	u32 fmt;
 	bool cleanup;
 
-	RawTrackFile(FILE* file,u32 file_offs,u32 first_fad,u32 secfmt)
+	RawTrackFile(core_file* file,u32 file_offs,u32 first_fad,u32 secfmt)
 	{
 		verify(file!=0);
 		this->file=file;
@@ -289,13 +291,13 @@ struct RawTrackFile : TrackFile
 			verify(false);
 		}
 
-		fseek(file,offset+FAD*fmt,SEEK_SET);
-		fread(dst,1,fmt,file);
+		core_fseek(file,offset+FAD*fmt,SEEK_SET);
+		core_fread(file, dst, fmt);
 	}
 	virtual ~RawTrackFile()
 	{
 		if (cleanup && file)
-			fclose(file);
+			core_fclose(file);
 	}
 };
 


### PR DESCRIPTION
- Fix coreio fsize
- Fix coreio fopen to seek to 0
- Fix coreio/http to smart-escape urls
-  For urls that include \ or % in the filenames, you have to pass them
   escaped
- Update gdi parser to use (mostly) streamstream. That code is horrible
  and should be rewritten
- coreio core is hacky and horrible at places as well
- Update imgreader to use coreio
- Update cdi parser + driver to use coreio