### PR TITLE
reios: Add support for elf booting

### DIFF
--- a/core/cfg/cfg.cpp
+++ b/core/cfg/cfg.cpp
@@ -412,6 +412,26 @@ void  cfgLoadStr(const wchar * Section, const wchar * Key, wchar * Return,const 
 	}
 }
 
+string  cfgLoadStr(const wchar * Section, const wchar * Key, const wchar* Default)
+{
+	verify(Section != 0 && strlen(Section) != 0);
+	verify(Key != 0 && strlen(Key) != 0);
+	
+	if (Default == 0)
+		Default = "";
+	ConfigSection* cs = cfgdb.GetEntry(Section);
+	ConfigEntry* ce = cs->FindEntry(Key);
+	if (!ce)
+	{
+		cs->SetEntry(Key, Default, CEM_SAVE);
+		return Default;
+	}
+	else
+	{
+		return ce->GetValue();
+	}
+}
+
 //These are helpers , mainly :)
 s32  cfgLoadInt(const wchar * Section, const wchar * Key,s32 Default)
 {

--- a/core/cfg/cfg.h
+++ b/core/cfg/cfg.h
@@ -13,6 +13,7 @@ bool cfgOpen();
 s32   cfgLoadInt(const wchar * lpSection, const wchar * lpKey,s32 Default);
 void  cfgSaveInt(const wchar * lpSection, const wchar * lpKey, s32 Int);
 void  cfgLoadStr(const wchar * lpSection, const wchar * lpKey, wchar * lpReturn,const wchar* lpDefault);
+string  cfgLoadStr(const wchar * Section, const wchar * Key, const wchar* Default);
 void  cfgSaveStr(const wchar * lpSection, const wchar * lpKey, const wchar * lpString);
 s32  cfgExists(const wchar * Section, const wchar * Key);
 void cfgSetVitual(const wchar * lpSection, const wchar * lpKey, const wchar * lpString);

--- a/core/cfg/cl.cpp
+++ b/core/cfg/cl.cpp
@@ -126,6 +126,15 @@ bool ParseCommandLine(int argc,wchar* argv[])
 			cl-=as;
 			arg+=as;
 		}
+		else if (strstr(*arg, ".cdi") || strstr(*arg, ".chd")) {
+			printf("Using '%s' as cd image\n", *arg);
+			cfgSetVitual("config", "image", *arg);
+		}
+		else if (strstr(*arg, ".elf")) {
+			printf("Using '%s' as reios elf file\n", *arg);
+			cfgSetVitual("config", "reios.enabled", "1");
+			cfgSetVitual("reios", "ElfFile", *arg);
+		}
 		else
 		{
 			printf("wtf %s is suposed to do ?\n",*arg);

--- a/core/hw/gdrom/gdromv3.cpp
+++ b/core/hw/gdrom/gdromv3.cpp
@@ -1031,7 +1031,9 @@ void WriteMem_gdrom(u32 Addr, u32 data, u32 sz)
 		break;
 
 	case GD_DRVSEL: 
-		printf("GDROM: Write to GD_DRVSEL\n");
+		if (data != 0) {
+			printf("GDROM: Write to GD_DRVSEL, !=0. Value is: %02X\n", data);
+		}
 		DriveSel = data; 
 		break;
 

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -251,6 +251,8 @@ void LoadSettings()
 	settings.pvr.rend				= cfgLoadInt("config","pvr.rend",0);
 
 	settings.debug.SerialConsole = cfgLoadInt("config", "Debug.SerialConsoleEnabled", 0) != 0;
+
+	settings.reios.ElfFile = cfgLoadStr("reios", "ElfFile","");
 #endif
 
 	settings.bios.UseReios = cfgLoadInt("config", "bios.UseReios", 0);

--- a/core/reios/reios.cpp
+++ b/core/reios/reios.cpp
@@ -9,6 +9,8 @@
 
 #include "reios.h"
 
+#include "reios_elf.h"
+
 #include "gdrom_hle.h"
 #include "descrambl.h"
 
@@ -122,75 +124,6 @@ const char* reios_locate_ip() {
 			break;
 		reios_bootfile[i] = 0;
 	}
-	/*
-		Post Boot registers from actual bios boot
-	r
-		[0x00000000]	0xac0005d8
-		[0x00000001]	0x00000009
-		[0x00000002]	0xac00940c
-		[0x00000003]	0x00000000
-		[0x00000004]	0xac008300
-		[0x00000005]	0xf4000000
-		[0x00000006]	0xf4002000
-		[0x00000007]	0x00000070
-		[0x00000008]	0x00000000
-		[0x00000009]	0x00000000
-		[0x0000000a]	0x00000000
-		[0x0000000b]	0x00000000
-		[0x0000000c]	0x00000000
-		[0x0000000d]	0x00000000
-		[0x0000000e]	0x00000000
-		[0x0000000f]	0x8d000000
-	mac	
-		l	0x5bfcb024
-		h	0x00000000
-	r_bank
-		[0x00000000]	0xdfffffff
-		[0x00000001]	0x500000f1
-		[0x00000002]	0x00000000
-		[0x00000003]	0x00000000
-		[0x00000004]	0x00000000
-		[0x00000005]	0x00000000
-		[0x00000006]	0x00000000
-		[0x00000007]	0x00000000
-	gbr	0x8c000000
-	ssr	0x40000001
-	spc	0x8c000776
-	sgr	0x8d000000
-	dbr	0x8c000010
-	vbr	0x8c000000
-	pr	0xac00043c
-	fpul	0x00000000
-	pc	0xac008300
-
-	+		sr	{T=1 status = 0x400000f0}
-	+		fpscr	{full=0x00040001}
-	+		old_sr	{T=1 status=0x400000f0}
-	+		old_fpscr	{full=0x00040001}
-
-	*/
-
-	//Setup registers to immitate a normal boot
-	sh4rcb.cntx.r[15] = 0x8d000000;
-
-	sh4rcb.cntx.gbr = 0x8c000000;
-	sh4rcb.cntx.ssr = 0x40000001;
-	sh4rcb.cntx.spc = 0x8c000776;
-	sh4rcb.cntx.sgr = 0x8d000000;
-	sh4rcb.cntx.dbr = 0x8c000010;
-	sh4rcb.cntx.vbr = 0x8c000000;
-	sh4rcb.cntx.pr = 0xac00043c;
-	sh4rcb.cntx.fpul = 0x00000000;
-	sh4rcb.cntx.pc = 0xac008300;
-
-	sh4rcb.cntx.sr.status = 0x400000f0;
-	sh4rcb.cntx.sr.T = 1;
-
-	sh4rcb.cntx.old_sr.status = 0x400000f0;
-
-	sh4rcb.cntx.fpscr.full = 0x00040001;
-	sh4rcb.cntx.old_fpscr.full = 0x00040001;
-
 	return reios_bootfile;
 }
 
@@ -421,6 +354,77 @@ void setup_syscall(u32 hook_addr, u32 syscall_addr) {
 	debugf("reios: - address %08X: data %04X [%04X]\n", hook_addr, ReadMem16(hook_addr), REIOS_OPCODE);
 }
 
+void reios_setup_state(u32 boot_addr) {
+	/*
+	Post Boot registers from actual bios boot
+	r
+	[0x00000000]	0xac0005d8
+	[0x00000001]	0x00000009
+	[0x00000002]	0xac00940c
+	[0x00000003]	0x00000000
+	[0x00000004]	0xac008300
+	[0x00000005]	0xf4000000
+	[0x00000006]	0xf4002000
+	[0x00000007]	0x00000070
+	[0x00000008]	0x00000000
+	[0x00000009]	0x00000000
+	[0x0000000a]	0x00000000
+	[0x0000000b]	0x00000000
+	[0x0000000c]	0x00000000
+	[0x0000000d]	0x00000000
+	[0x0000000e]	0x00000000
+	[0x0000000f]	0x8d000000
+	mac
+	l	0x5bfcb024
+	h	0x00000000
+	r_bank
+	[0x00000000]	0xdfffffff
+	[0x00000001]	0x500000f1
+	[0x00000002]	0x00000000
+	[0x00000003]	0x00000000
+	[0x00000004]	0x00000000
+	[0x00000005]	0x00000000
+	[0x00000006]	0x00000000
+	[0x00000007]	0x00000000
+	gbr	0x8c000000
+	ssr	0x40000001
+	spc	0x8c000776
+	sgr	0x8d000000
+	dbr	0x8c000010
+	vbr	0x8c000000
+	pr	0xac00043c
+	fpul	0x00000000
+	pc	0xac008300
+
+	+		sr	{T=1 status = 0x400000f0}
+	+		fpscr	{full=0x00040001}
+	+		old_sr	{T=1 status=0x400000f0}
+	+		old_fpscr	{full=0x00040001}
+
+	*/
+
+	//Setup registers to immitate a normal boot
+	sh4rcb.cntx.r[15] = 0x8d000000;
+
+	sh4rcb.cntx.gbr = 0x8c000000;
+	sh4rcb.cntx.ssr = 0x40000001;
+	sh4rcb.cntx.spc = 0x8c000776;
+	sh4rcb.cntx.sgr = 0x8d000000;
+	sh4rcb.cntx.dbr = 0x8c000010;
+	sh4rcb.cntx.vbr = 0x8c000000;
+	sh4rcb.cntx.pr = 0xac00043c;
+	sh4rcb.cntx.fpul = 0x00000000;
+	sh4rcb.cntx.pc = boot_addr;
+
+	sh4rcb.cntx.sr.status = 0x400000f0;
+	sh4rcb.cntx.sr.T = 1;
+
+	sh4rcb.cntx.old_sr.status = 0x400000f0;
+
+	sh4rcb.cntx.fpscr.full = 0x00040001;
+	sh4rcb.cntx.old_fpscr.full = 0x00040001;
+}
+
 void reios_boot() {
 	//setup syscalls
 	//find boot file
@@ -438,9 +442,19 @@ void reios_boot() {
 	//Infinitive loop for arm !
 	WriteMem32(0x80800000, 0xEAFFFFFE);
 
-	const char* bootfile = reios_locate_ip();
-	if (!bootfile || !reios_locate_bootfile(bootfile))
-		msgboxf("Failed to locate bootfile", MBX_ICONERROR);
+	if (settings.reios.ElfFile.size()) {
+		if (!reios_loadElf(settings.reios.ElfFile)) {
+			msgboxf("Failed to open %s\n", MBX_ICONERROR, settings.reios.ElfFile.c_str());
+		}
+		reios_setup_state(0x8C010000);
+	}
+	
+	else {
+		const char* bootfile = reios_locate_ip();
+		if (!bootfile || !reios_locate_bootfile(bootfile))
+			msgboxf("Failed to locate bootfile", MBX_ICONERROR);
+		reios_setup_state(0xac008300);
+	}
 }
 
 map<u32, hook_fp*> hooks;

--- a/core/reios/reios_elf.cpp
+++ b/core/reios/reios_elf.cpp
@@ -1,0 +1,57 @@
+#include "reios.h"
+
+#include "deps/libelf/elf.h"
+
+#include "hw/sh4/sh4_mem.h"
+
+bool reios_loadElf(const string& elf) {
+
+	FILE* f = fopen(elf.c_str(), "rb");
+	if (!f) {
+		return false;
+	}
+	fseek(f, 0, SEEK_END);
+	size_t size = ftell(f);
+
+	if (size > 16 * 1024 * 1024) {
+		return false;
+	}
+
+	void* elfFile = malloc(size);
+	memset(elfFile, 0, size);
+
+	fseek(f, 0, SEEK_SET);
+	fread(elfFile, 1, size, f);
+	fclose(f);
+
+	int i;
+	bool phys = false;
+
+
+	if (elf_checkFile(elfFile) != 0) {
+		free(elfFile);
+		return false;
+	}
+
+	for (i = 0; i < elf_getNumProgramHeaders(elfFile); i++) {
+		/* Load that section */
+		uint64_t dest, src;
+		size_t len;
+		if (phys) {
+			dest = elf_getProgramHeaderPaddr(elfFile, i);
+		}
+		else {
+			dest = elf_getProgramHeaderVaddr(elfFile, i);
+		}
+		len = elf_getProgramHeaderFileSize(elfFile, i);
+		src = (uint64_t)(uintptr_t)elfFile + elf_getProgramHeaderOffset(elfFile, i);
+		
+		u8* ptr = GetMemPtr(dest, len);
+
+		memcpy((void*)ptr, (void*)(uintptr_t)src, len);
+		ptr += len;
+		memset((void*)ptr, 0, elf_getProgramHeaderMemorySize(elfFile, i) - len);
+	}
+
+	return true;
+}

--- a/core/reios/reios_elf.h
+++ b/core/reios/reios_elf.h
@@ -1,0 +1,3 @@
+#include "types.h"
+
+bool reios_loadElf(const string& elf);

--- a/core/types.h
+++ b/core/types.h
@@ -594,6 +594,10 @@ struct settings_t
 		bool UseReios;
 	} bios;
 
+	struct {
+		string ElfFile;
+	} reios;
+
 	struct
 	{
 		bool UseMipmaps;

--- a/core/windows/win86_driver.cpp
+++ b/core/windows/win86_driver.cpp
@@ -746,7 +746,11 @@ bool ngen_Rewrite(unat& addr,unat retadr,unat acc)
 				{
 					//found !
 
-					if ((acc >> 26) == 0x38) //sq ?
+					if ((acc >> 26) == 0x38 && !w) {
+						printf("WARNING: SQ AREA READ, %08X from sh4:%08X. THIS IS UNDEFINED ON A REAL DREACMAST.\n", acc, bm_GetBlock(x86e->x86_buff)->addr);
+					}
+
+					if ((acc >> 26) == 0x38 && w) //sq ?
 					{
 						verify(w == 1);
 						x86e->Emit(op_call, x86_ptr_imm(mem_code[1][w][i]));

--- a/shell/reicast.vcxproj
+++ b/shell/reicast.vcxproj
@@ -160,6 +160,7 @@
     <ClCompile Include="..\core\reios\descrambl.cpp" />
     <ClCompile Include="..\core\reios\gdrom_hle.cpp" />
     <ClCompile Include="..\core\reios\reios.cpp" />
+    <ClCompile Include="..\core\reios\reios_elf.cpp" />
     <ClCompile Include="..\core\rend\d3d11\d3d11.cpp" />
     <ClCompile Include="..\core\rend\gles\gldraw.cpp" />
     <ClCompile Include="..\core\rend\gles\gles.cpp" />
@@ -292,6 +293,7 @@
     <ClInclude Include="..\core\reios\descrambl.h" />
     <ClInclude Include="..\core\reios\gdrom_hle.h" />
     <ClInclude Include="..\core\reios\reios.h" />
+    <ClInclude Include="..\core\reios\reios_elf.h" />
     <ClInclude Include="..\core\rend\gles\gles.h" />
     <ClInclude Include="..\core\rend\rend.h" />
     <ClInclude Include="..\core\rend\TexCache.h" />

--- a/shell/reicast.vcxproj.filters
+++ b/shell/reicast.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClCompile Include="..\core\reios\descrambl.cpp">
       <Filter>reios</Filter>
     </ClCompile>
+    <ClCompile Include="..\core\reios\reios_elf.cpp">
+      <Filter>reios</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="hw">
@@ -887,6 +890,9 @@
       <Filter>reios</Filter>
     </ClInclude>
     <ClInclude Include="..\core\reios\descrambl.h">
+      <Filter>reios</Filter>
+    </ClInclude>
+    <ClInclude Include="..\core\reios\reios_elf.h">
       <Filter>reios</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This implements elf booting via reios, using the existing elf parser (which is/was needed as part of reprof)

As a bonus, .elf, .cdi and .chd files are now automatically detected on the command line. 

`./reicast.elf game.elf game.cdi` will boot without asking for cd, trying to mount `game.cdi`

`./reicast game.chd` and `./reicast game.cdi`  will try to boot that image.

These are just shorthands for -config reios:ElfFile=... and -config config:image=....