### PR TITLE
Update for ndk-10d, improved build options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ before_install:
 - GIT_HASH=`git log --pretty=format:'%h' -n 1`
 - GIT_BUILD=`git describe --all`-$GIT_HASH
 install:
-- download_extract http://dl.google.com/android/ndk/android-ndk-r9c-linux-x86_64.tar.bz2
-  android-ndk-r9c-linux-x86_64.tar.bz2
+- wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-x86_64.bin
+- chmod +x android-ndk-r10d-linux-x86_64.bin
+- ./android-ndk-r10d-linux-x86_64.bin
+- mv android-ndk-r10d android-ndk
+- rm android-ndk-r10d-linux-x86_64.bin
 - download_extract_zip http://dl.google.com/android/adt/adt-bundle-linux-x86_64-20131030.zip
   adt-bundle-linux-x86_64-20131030.zip
-- mv android-ndk-r9c android-ndk
 - mv adt-bundle-linux-x86_64-20131030/sdk/ android-sdk
-- rm android-ndk-r9c-linux-x86_64.tar.bz2
 - rm adt-bundle-linux-x86_64-20131030.zip
 - export ANDROID_HOME=$(pwd)/android-sdk
 - export NDK=$(pwd)/android-ndk

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 install:
 - wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-x86_64.bin
 - chmod +x android-ndk-r10d-linux-x86_64.bin
-- ./android-ndk-r10d-linux-x86_64.bin > /dev/null
+- ./android-ndk-r10d-linux-x86_64.bin -y | grep -v Extracting
 - mv android-ndk-r10d android-ndk
 - rm android-ndk-r10d-linux-x86_64.bin
 - download_extract_zip http://dl.google.com/android/adt/adt-bundle-linux-x86_64-20131030.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 install:
 - wget http://dl.google.com/android/ndk/android-ndk-r10d-linux-x86_64.bin
 - chmod +x android-ndk-r10d-linux-x86_64.bin
-- ./android-ndk-r10d-linux-x86_64.bin
+- ./android-ndk-r10d-linux-x86_64.bin > /dev/null
 - mv android-ndk-r10d android-ndk
 - rm android-ndk-r10d-linux-x86_64.bin
 - download_extract_zip http://dl.google.com/android/adt/adt-bundle-linux-x86_64-20131030.zip

--- a/core/core.mk
+++ b/core/core.mk
@@ -2,7 +2,7 @@
 
 #MFLAGS	:= -marm -march=armv7-a -mtune=cortex-a8 -mfpu=vfpv3-d16 -mfloat-abi=softfp
 #ASFLAGS	:= -march=armv7-a -mfpu=vfp-d16 -mfloat-abi=softfp
-#LDFLAGS	:= -g -Wl,-Map,$(notdir $@).map,--gc-sections -Wl,-O3 -Wl,--sort-common 
+#LDFLAGS	:= -Wl,-Map,$(notdir $@).map,--gc-sections -Wl,-O3 -Wl,--sort-common 
 
 RZDCY_SRC_DIR ?= $(call my-dir)
 
@@ -53,7 +53,7 @@ RZDCY_FILES += $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(w
 	
 ifdef FOR_PANDORA
 RZDCY_CFLAGS	:= \
-	$(CFLAGS) -c -g -O3 -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps \
+	$(CFLAGS) -c -O3 -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps \
 	-DRELEASE -DPANDORA\
 	-march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp \
 	-frename-registers -fsingle-precision-constant -ffast-math \
@@ -62,7 +62,7 @@ RZDCY_CFLAGS	:= \
 	RZDCY_CFLAGS += -DTARGET_LINUX_ARMELv7
 else
 RZDCY_CFLAGS	:= \
-	$(CFLAGS) -c -g -O3 -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps \
+	$(CFLAGS) -c -O3 -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps \
 	-D_ANDROID -DRELEASE\
 	-frename-registers -fsingle-precision-constant -ffast-math \
 	-ftree-vectorize -fomit-frame-pointer

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -17,6 +17,7 @@
 
 #if defined(_ANDROID)
 #include <asm/sigcontext.h>
+#if 0
 typedef struct ucontext_t {
 unsigned long uc_flags;
 struct ucontext_t *uc_link;
@@ -31,17 +32,18 @@ struct sigcontext uc_mcontext;
 */
 } ucontext_t;
 #endif
+#endif
 
 #if HOST_CPU == CPU_ARM
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.arm_pc)
 #elif HOST_CPU == CPU_MIPS
-#ifdef _ANDROID
+#if 0 && _ANDROID
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.sc_pc)
 #else
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.pc)
 #endif
 #elif HOST_CPU == CPU_X86
-#ifdef _ANDROID
+#if 0 && _ANDROID
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.eip)
 #else
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.gregs[REG_EIP])

--- a/core/linux/nixprof.cpp
+++ b/core/linux/nixprof.cpp
@@ -35,7 +35,7 @@
 
 #if defined(_ANDROID)
 #include <asm/sigcontext.h>
-
+#if 0
 typedef struct ucontext_t
 {
 	unsigned long uc_flags;
@@ -52,20 +52,20 @@ typedef struct ucontext_t
 	 * we don't use them for now...
 	 */
 } ucontext_t;
-
+#endif
 #include <android/log.h> 
 #endif
 
 #if HOST_CPU == CPU_ARM
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.arm_pc)
 #elif HOST_CPU == CPU_MIPS
-#ifdef _ANDROID
+#if 0 && _ANDROID
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.sc_pc)
 #else
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.pc)
 #endif
 #elif HOST_CPU == CPU_X86
-#ifdef _ANDROID
+#if 0 && _ANDROID
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.eip)
 #else
 #define GET_PC_FROM_CONTEXT(c) (((ucontext_t *)(c))->uc_mcontext.gregs[REG_EIP])

--- a/core/rec-ARM/ngen_arm.S
+++ b/core/rec-ARM/ngen_arm.S
@@ -11,6 +11,7 @@
 @@@@@@@@@@ some helpers @@@@@@@@@@
 
 .global do_sqw_nommu_area_3
+.hidden do_sqw_nommu_area_3
 @r0: addr
 @r1: sq_both
 do_sqw_nommu_area_3:
@@ -25,6 +26,7 @@ vstm r3,{d0-d3}
 bx lr
 
 .global TAWriteSQ
+.hidden TAWriteSQ
 @r0: addr
 @r1: sq_both
 TAWriteSQ:
@@ -57,6 +59,7 @@ bx lr
 @@@@@@@@@@ ngen_LinkBlock_*****_stub @@@@@@@@@@
 
 .global ngen_LinkBlock_Generic_stub
+.hidden ngen_LinkBlock_Generic_stub
 ngen_LinkBlock_Generic_stub:
 
     mov r1,r4	@ djump/pc -> in case we need it ..
@@ -64,12 +67,14 @@ ngen_LinkBlock_Generic_stub:
 
 
 .global ngen_LinkBlock_cond_Branch_stub
+.hidden ngen_LinkBlock_cond_Branch_stub
 ngen_LinkBlock_cond_Branch_stub:
 
 	mov r1,#1
 	b ngen_LinkBlock_Shared_stub
     
 .global ngen_LinkBlock_cond_Next_stub    
+.hidden ngen_LinkBlock_cond_Next_stub    
 ngen_LinkBlock_cond_Next_stub:
 
 	mov r1,#0
@@ -77,6 +82,7 @@ ngen_LinkBlock_cond_Next_stub:
 
 
 .global ngen_LinkBlock_Shared_stub
+.hidden ngen_LinkBlock_Shared_stub
 ngen_LinkBlock_Shared_stub:
 
 	mov r0,lr
@@ -88,6 +94,7 @@ ngen_LinkBlock_Shared_stub:
 
 
 .global ngen_FailedToFindBlock_
+.hidden ngen_FailedToFindBlock_
 ngen_FailedToFindBlock_:
 	mov r0,r4
     bl rdv_FailedToFindBlock
@@ -96,6 +103,7 @@ ngen_FailedToFindBlock_:
 @@@@@@@@@@ ngen_blockcheckfail @@@@@@@@@@
 
 .global ngen_blockcheckfail
+.hidden ngen_blockcheckfail
 ngen_blockcheckfail:
     bl rdv_BlockCheckFail
     bx r0
@@ -111,6 +119,7 @@ ngen_blockcheckfail:
 
 
 .global ngen_mainloop
+.hidden ngen_mainloop
 ngen_mainloop:
 
 push { r4-r12,lr }
@@ -125,7 +134,8 @@ push { r4-r12,lr }
 
 
 	@this code is here for fall-through behavior of do_iter
-	.global intc_sched
+.global intc_sched
+.hidden intc_sched
 intc_sched:        @ next_pc _MUST_ be on ram
     add r9,r9,#SH4_TIMESLICE
 	mov r4,lr
@@ -140,6 +150,7 @@ do_iter:
 	mov r4,r0
 
 .global no_update
+.hidden no_update
 no_update:              @ next_pc _MUST_ be on r4 *R4 NOT R0 anymore*
 
 	sub r2,r8,#33816576
@@ -157,6 +168,7 @@ end_ngen_mainloop:
 @@@@@@@@@@ ngen_mainloop @@@@@@@@@@
 
 .global arm_compilecode
+.hidden arm_compilecode
 arm_compilecode:
 bl CompileCode
 b arm_dispatch
@@ -166,7 +178,8 @@ Xarm_Reg: .word arm_Reg
 XEntryPoints: .word EntryPoints
 #endif
 
-.global arm_mainloop
+.global arm_mainloop 
+.hidden arm_mainloop 
 arm_mainloop: @(cntx,lookup_base,cycles)
 
 push {r4,r5,r8,r9,lr}
@@ -185,6 +198,7 @@ push {r4,r5,r8,r9,lr}
 	b arm_dispatch
 
 .global arm_dispatch
+.hidden arm_dispatch
 arm_dispatch:
 	#ifdef TARGET_IPHONE
 	ldrd r0,r1,[r8,#184]		@load: Next PC, interrupt
@@ -203,6 +217,7 @@ arm_dofiq:
 	b arm_dispatch
 
 .global arm_exit
+.hidden arm_exit
 arm_exit:
 	str r5,[r8,#192]		@if timeslice is over, save remaining cycles
 	pop {r4,r5,r8,r9,pc}	
@@ -211,6 +226,7 @@ arm_exit:
 @matrix mul
 #ifndef _ANDROID
 .global ftrv_asm
+.hidden ftrv_asm
 ftrv_asm:
 
 @r0=dst,r1=vec,r2=mtx
@@ -229,6 +245,7 @@ vstm r0,{d4,d5}
 bx lr
 
 .global fipr_asm
+.hidden fipr_asm
 fipr_asm:
 
 @ vdot

--- a/shell/android/jni/Android.mk
+++ b/shell/android/jni/Android.mk
@@ -36,18 +36,27 @@ include $(LOCAL_PATH)/../../core/core.mk
 LOCAL_SRC_FILES := $(RZDCY_FILES)
 LOCAL_SRC_FILES += $(wildcard $(LOCAL_PATH)/jni/src/Android.cpp)
 LOCAL_SRC_FILES += $(wildcard $(LOCAL_PATH)/jni/src/utils.cpp)
-LOCAL_CFLAGS  := $(RZDCY_CFLAGS)
-LOCAL_CXXFLAGS  := $(RZDCY_CXXFLAGS)
+LOCAL_CFLAGS  := $(RZDCY_CFLAGS) -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections
+LOCAL_CXXFLAGS  := $(RZDCY_CXXFLAGS) -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections
+LOCAL_CPPFLAGS  := $(RZDCY_CXXFLAGS) -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections
 
+LOCAL_CPP_FEATURES := 
 LOCAL_SHARED_LIBRARIES:= libcutils libutils
 LOCAL_PRELINK_MODULE  := false
 
 LOCAL_MODULE	:= dc
 LOCAL_DISABLE_FORMAT_STRING_CHECKS=true
 LOCAL_ASFLAGS := -fvisibility=hidden
-LOCAL_LDLIBS	:= -llog -lGLESv2 -lEGL -lz
+LOCAL_LDLIBS	:= -llog -lGLESv2 -lEGL -lz 
 #-Wl,-Map,./res/raw/syms.mp3
 LOCAL_ARM_MODE	:= arm
+
+
+ifeq ($(TARGET_ARCH),mips)
+  LOCAL_LDFLAGS += -Wl,--gc-sections
+else
+  LOCAL_LDFLAGS += -Wl,--gc-sections,--icf=safe
+endif
 
 #
 # android has poor support for hardfp calling.

--- a/shell/android/jni/Application.mk
+++ b/shell/android/jni/Application.mk
@@ -2,4 +2,4 @@ APP_STL		:= stlport_static
 APP_ABI 	:= armeabi-v7a x86 mips
 #APP_ABI		:= armeabi-v7a
 APP_PLATFORM	:= android-19
-NDK_TOOLCHAIN_VERSION := 4.8
+#NDK_TOOLCHAIN_VERSION := 4.8

--- a/shell/android/project.properties
+++ b/shell/android/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
+target=android-21

--- a/shell/android/res/values-ko/strings.xml
+++ b/shell/android/res/values-ko/strings.xml
@@ -91,7 +91,7 @@
     <string name="popup_button_disk">Disk Swap</string>
     <string name="popup_button_vmu_swap">VMU Swap</string>
     <string name="popup_button_options">설정 메뉴</string>
-    <string name="popup_button_debugging">디버그 메뉴/string>
+    <string name="popup_button_debugging">디버그 메뉴</string>
     <string name="popup_button_screenshot">스크린샷</string>
     <string name="popup_button_exit">종료</string>
     <string name="popup_button_clear_cache">캐시 삭제</string>


### PR DESCRIPTION
Today I found out that android by default exports all symbols, and uses dynamic linking on them. This applies even for "internal" symbols, as everything is exported by default. Some other opts were enabled too, and minor changes on nixprof/common/travix for ndk r10d.

- Makes all symbols hidden by default (pro tip: `nm -D <so file>`)
- Disables all debug info. Debug info is *not* always zero cost on gcc.
- Enable per function GC
- ndk r10d uses same register names as desktop linux (yay!)

Would be great if someone tested the speed of these changes and reported back. Use [this CI build apk](http://reicast-builds.s3.amazonaws.com/builds/heads/features/use-ndk-r10d-7abd154/reicast-android-debug-7abd154.apk).