### PR TITLE
Remove arm_dyna typedef default args

### DIFF
--- a/core/rec-ARM/arm_dyna.cpp
+++ b/core/rec-ARM/arm_dyna.cpp
@@ -183,10 +183,10 @@ typedef ConditionCode eCC;
 #define rfp_r9 r9
 
 
-typedef void FPBinOP        (eFSReg Sd, eFSReg Sn, eFSReg Sm, ConditionCode CC=CC_AL);
-typedef void FPUnOP         (eFSReg Sd, eFSReg Sm,            ConditionCode CC=CC_AL);
-typedef void BinaryOP       (eReg Rd, eReg Rn, eReg Rm,       ConditionCode CC=AL);
-typedef void BinaryOPImm    (eReg Rd, eReg Rn, s32 sImm8,     ConditionCode CC=AL);
+typedef void FPBinOP        (eFSReg Sd, eFSReg Sn, eFSReg Sm, ConditionCode CC);
+typedef void FPUnOP         (eFSReg Sd, eFSReg Sm,            ConditionCode CC);
+typedef void BinaryOP       (eReg Rd, eReg Rn, eReg Rm,       ConditionCode CC);
+typedef void BinaryOPImm    (eReg Rd, eReg Rn, s32 sImm8,     ConditionCode CC);
 typedef void UnaryOP        (eReg Rd, eReg Rs);
 
 


### PR DESCRIPTION
Using default arguments is only allowed in function declarations, not
in typedefs. This fixes the invalid code that caused compilation errors
on systems using GNU g++ 4.9.2, i.e.:

> ../../core/rec-ARM/arm_dyna.cpp: At global scope:
> ../../core/rec-ARM/arm_dyna.cpp:186:79: error: default arguments are only permitted for function parameters
>  typedef void FPBinOP        (eFSReg Sd, eFSReg Sn, eFSReg Sm, ConditionCode CC=CC_AL);
>                                                                                ^
> ../../core/rec-ARM/arm_dyna.cpp:187:79: error: default arguments are only permitted for function parameters
>  typedef void FPUnOP         (eFSReg Sd, eFSReg Sm,            ConditionCode CC=CC_AL);
>                                                                                ^
> ../../core/rec-ARM/arm_dyna.cpp:188:79: error: default arguments are only permitted for function parameters
>  typedef void BinaryOP       (eReg Rd, eReg Rn, eReg Rm,       ConditionCode CC=AL);
>                                                                                ^
> ../../core/rec-ARM/arm_dyna.cpp:189:79: error: default arguments are only permitted for function parameters
>  typedef void BinaryOPImm    (eReg Rd, eReg Rn, s32 sImm8,     ConditionCode CC=AL);
>                                                                                ^
> ../../core/rec-ARM/arm_dyna.cpp:771:10: warning: anonymous type with no linkage used to declare variable '<anonymous struct> op_table []' with linkage
>  op_table[]=
>           ^
> Makefile:89: recipe for target 'obj/rec-ARM/arm_dyna.build_obj' failed
> make: *** [obj/rec-ARM/arm_dyna.build_obj] Error 1