### PR TITLE
Feat/no direct memmap

### DIFF
--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -401,8 +401,8 @@ void recSh4_Init()
 	verify(rcb_noffs(&p_sh4rcb->cntx.sh4_sched_next)==-152);
 	verify(rcb_noffs(&p_sh4rcb->cntx.interrupt_pend)==-148);
 	
-
-	verify(mem_b.data==((u8*)p_sh4rcb->sq_buffer+512+0x0C000000));
+	
+	//verify(mem_b.data==((u8*)p_sh4rcb->sq_buffer+512+0x0C000000));
 
 	//align to next page ..
     CodeCache = (u8*)(((unat)SH4_TCB+4095)& ~4095);

--- a/core/hw/sh4/interpr/sh4_opcodes.cpp
+++ b/core/hw/sh4/interpr/sh4_opcodes.cpp
@@ -1301,7 +1301,7 @@ void DYNACALL do_sqw_mmu(u32 dst) { do_sqw<true>(dst); }
 #if HOST_CPU!=CPU_ARM
 extern "C" void DYNACALL do_sqw_nommu_area_3(u32 dst,u8* sqb)
 {
-	u8* pmem=sqb+512+0x0C000000;
+	u8* pmem = mem_b.data;// sqb + 512 + 0x0C000000;
 
 	memcpy((u64*)&pmem[dst&(RAM_MASK-0x1F)],(u64*)&sqb[dst & 0x20],32);
 }

--- a/core/hw/sh4/interpr/sh4_opcodes.cpp
+++ b/core/hw/sh4/interpr/sh4_opcodes.cpp
@@ -1298,7 +1298,7 @@ INLINE void DYNACALL do_sqw(u32 Dest)
 }
 
 void DYNACALL do_sqw_mmu(u32 dst) { do_sqw<true>(dst); }
-#if HOST_CPU!=CPU_ARM
+#if 1
 extern "C" void DYNACALL do_sqw_nommu_area_3(u32 dst,u8* sqb)
 {
 	u8* pmem = mem_b.data;// sqb + 512 + 0x0C000000;

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -76,7 +76,9 @@ void fault_handler (int sn, siginfo_t * si, void *ctxr)
 #endif
 	else
 	{
-		printf("SIGSEGV @ fault_handler+0x%08X ... %08X -> was not in vram\n",GET_PC_FROM_CONTEXT(ctxr)-(u32)fault_handler,si->si_addr);
+#ifndef HOST_NO_REC
+		printf("SIGSEGV @ fault_handler+0x%08X ... %08X -> was not in vram %d\n", GET_PC_FROM_CONTEXT(ctxr) - (u32)fault_handler, si->si_addr, dyna_cde);
+#endif
 		die("segfault");
 //		asm volatile("bkpt 0x0001\n\t");
 		signal(SIGSEGV, SIG_DFL);

--- a/core/rec-ARM/arm_dyna.cpp
+++ b/core/rec-ARM/arm_dyna.cpp
@@ -1127,31 +1127,31 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			{
 				eReg raddr=GenMemAddr(op);
 
-				BIC(r1,raddr,0xE0000000);
+				BIC(r1,raddr,0x00000000);
 				//UBFX(r1,raddr,0,29);
 				//SUB(r1,raddr,raddr);
 
 				switch(optp)
 				{
 				case SZ_8:	
-					LDRSB(reg.mapg(op->rd),r1,r8,true); 
+					LDRSB(reg.mapg(op->rd), r1, r1, true);
 					break;
 
 				case SZ_16: 
-					LDRSH(reg.mapg(op->rd),r1,r8,true); 
+					LDRSH(reg.mapg(op->rd), r1, r1, true);
 					break;
 
 				case SZ_32I: 
-					LDR(reg.mapg(op->rd),r1,r8,Offset,true); 
+					LDR(reg.mapg(op->rd), r1, r1, Offset, true);
 					break;
 
 				case SZ_32F:
-					ADD(r1,r1,r8);	//3 opcodes, there's no [REG+REG] VLDR
+					ADD(r1, r1, r1);	//3 opcodes, there's no [REG+REG] VLDR
 					VLDR(reg.mapf(op->rd),r1,0);
 					break;
 
 				case SZ_64F:
-					ADD(r1,r1,r8);	//3 opcodes, there's no [REG+REG] VLDR
+					ADD(r1, r1, r1);	//3 opcodes, there's no [REG+REG] VLDR
 					VLDR(d0,r1,0);	//TODO: use reg alloc
 
 					VSTR(d0,r8,op->rd.reg_nofs()/4);
@@ -1172,7 +1172,7 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			if (optp == SZ_64F)
 				VLDR(d0,r8,op->rs2.reg_nofs()/4);
 
-			BIC(r1,raddr,0xE0000000);
+			BIC(r1,raddr,0x00000000);
 			//UBFX(r1,raddr,0,29);
 			//SUB(r1,raddr,raddr);
 			
@@ -1180,18 +1180,19 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			switch(optp)
 			{
 			case SZ_8:
-				STRB(reg.mapg(op->rs2),r1,r8,Offset,true);
+				STRB(reg.mapg(op->rs2), r1, r1, Offset, true);
 				break;
 
 			case SZ_16:
-				STRH(reg.mapg(op->rs2),r1,r8,true);
+				STRH(reg.mapg(op->rs2), r1, r1, true);
 				break;
 
 			case SZ_32I:
 				if (op->flags2!=0x1337)
-					STR(reg.mapg(op->rs2),r1,r8,Offset,true); 
+					STR(reg.mapg(op->rs2),r1,r1,Offset,true); 
 				else
 				{
+					verify(false);
 					emit_Skip(-4);
 					AND(r1,raddr,0x3F);
 					ADD(r1,r1,r8);
@@ -1202,11 +1203,12 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			case SZ_32F:
 				if (op->flags2!=0x1337)
 				{
-					ADD(r1,r1,r8);	//3 opcodes: there's no [REG+REG] VLDR, also required for SQ
+					ADD(r1, r1, r1);	//3 opcodes: there's no [REG+REG] VLDR, also required for SQ
 					VSTR(reg.mapf(op->rs2),r1,0);
 				}
 				else
 				{
+					verify(false);
 					emit_Skip(-4);
 					AND(r1,raddr,0x3F);
 					ADD(r1,r1,r8);
@@ -1217,11 +1219,12 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			case SZ_64F:
 				if (op->flags2!=0x1337)
 				{
-					ADD(r1,r1,r8);	//3 opcodes: there's no [REG+REG] VLDR, also required for SQ
+					ADD(r1, r1, r1);	//3 opcodes: there's no [REG+REG] VLDR, also required for SQ
 					VSTR(d0,r1,0);	//TODO: use reg alloc
 				}
 				else
 				{
+					verify(false);
 					emit_Skip(-4);
 					AND(r1,raddr,0x3F);
 					ADD(r1,r1,r8);

--- a/core/rec-ARM/arm_dyna.cpp
+++ b/core/rec-ARM/arm_dyna.cpp
@@ -896,7 +896,7 @@ u32* ngen_readm_fail_v2(u32* ptrv,u32* regs,u32 fault_addr)
 	//printf("Failed %08X:%08X (%d,%d,%d,r%d, r%d,f%d,d%d) code %08X, addr %08X, native %08X (%08X), fixing via %s\n",ptr->full,fop,optp,read,offs,raddr,rt,ft,fd,ptr,sh4_addr,fault_addr,fault_offs,is_sq?"SQ":"MR");
 
 	//fault offset must always be the addr from ubfx (sanity check)
-	verify((fault_offs==0) || fault_offs==(0x1FFFFFFF&sh4_addr));
+	//verify((fault_offs==0) || fault_offs==(0x1FFFFFFF&sh4_addr));
 
 	if (settings.dynarec.unstable_opt && is_sq) //THPS2 uses cross area SZ_32F so this is disabled for now
 	{

--- a/core/rec-ARM/arm_dyna.cpp
+++ b/core/rec-ARM/arm_dyna.cpp
@@ -1127,7 +1127,7 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			{
 				eReg raddr=GenMemAddr(op);
 
-				BIC(r1,raddr,0x00000000);
+				AND(r1,raddr,0x00000000);
 				//UBFX(r1,raddr,0,29);
 				//SUB(r1,raddr,raddr);
 
@@ -1172,7 +1172,7 @@ void ngen_compile_opcode(RuntimeBlockInfo* block, shil_opcode* op, bool staging,
 			if (optp == SZ_64F)
 				VLDR(d0,r8,op->rs2.reg_nofs()/4);
 
-			BIC(r1,raddr,0x00000000);
+			AND(r1,raddr,0x00000000);
 			//UBFX(r1,raddr,0,29);
 			//SUB(r1,raddr,raddr);
 			

--- a/core/rec-ARM/ngen_arm.S
+++ b/core/rec-ARM/ngen_arm.S
@@ -10,11 +10,11 @@
 
 @@@@@@@@@@ some helpers @@@@@@@@@@
 
-.global do_sqw_nommu_area_3
-.hidden do_sqw_nommu_area_3
+.global do_sqw_nommu_area_3___
+.hidden do_sqw_nommu_area_3___
 @r0: addr
 @r1: sq_both
-do_sqw_nommu_area_3:
+do_sqw_nommu_area_3___:
 add r3,r1,#0x0C000000	@ get ram ptr from r1, part 1
 and r2,r0,#0x20			@ SQ# selection, isolate
 ubfx r0,r0,#5,#19		@ get ram offset

--- a/core/rend/TexCache.cpp
+++ b/core/rend/TexCache.cpp
@@ -192,7 +192,7 @@ vram_block* libCore_vramlock_Lock(u32 start_offset64,u32 end_offset64,void* user
 		vramlist_lock.Lock();
 	
 		vram.LockRegion(block->start,block->len);
-		vram.LockRegion(block->start + VRAM_SIZE,block->len);
+		//vram.LockRegion(block->start + VRAM_SIZE,block->len);
 		vramlock_list_add(block);
 		
 		vramlist_lock.Unlock();
@@ -232,7 +232,7 @@ bool VramLockedWrite(u8* address)
 			list->clear();
 
 			vram.UnLockRegion((u32)offset&(~(PAGE_SIZE-1)),PAGE_SIZE);
-			vram.UnLockRegion((u32)offset&(~(PAGE_SIZE-1)) + VRAM_SIZE,PAGE_SIZE);
+			//vram.UnLockRegion((u32)offset&(~(PAGE_SIZE-1)) + VRAM_SIZE,PAGE_SIZE);
 			
 			vramlist_lock.Unlock();
 		}

--- a/core/rend/gles/gltex.cpp
+++ b/core/rend/gles/gltex.cpp
@@ -210,7 +210,7 @@ struct TextureCacheData
 				//Call the format specific conversion code
 				texconv=tex->PL;
 				//calculate the size, in bytes, for the locking
-				size=w*h*tex->bpp/8;
+				size = stride*h*tex->bpp / 8;
 			}
 			else
 			{

--- a/core/windows/win86_driver.cpp
+++ b/core/windows/win86_driver.cpp
@@ -579,7 +579,19 @@ void gen_hande(u32 w, u32 sz, u32 mode)
 	{
 		//Buffer
 		x86e->Emit(op_mov32,EAX,ECX);
-		x86e->Emit(op_and32,ECX,0x1FFFFFFF);
+
+		if (virt_ram_base)
+		{
+			x86e->Emit(op_and32, ECX, 0x1FFFFFFF);
+		}
+		else
+		{
+			x86e->Emit(op_and32, ECX, 0);
+
+			x86e->Emit(op_nop);
+			x86e->Emit(op_nop);
+			x86e->Emit(op_nop);
+		}
 
 		x86_mrm_t buff=x86_mrm(ECX,virt_ram_base);
 		x86_mrm_t buff4=x86_mrm(ECX,virt_ram_base+4);

--- a/core/windows/win86_il.cpp
+++ b/core/windows/win86_il.cpp
@@ -498,7 +498,7 @@ void ngen_opcode(RuntimeBlockInfo* block, shil_opcode* op,x86_block* x86e, bool 
 				if (size<=8)
 				{
 
-					if (size==8 && optimise)
+					if (size == 8 && optimise && virt_ram_base)
 					{
 						verify(op->rd.count()==2 && reg.IsAllocf(op->rd,0) && reg.IsAllocf(op->rd,1));
 


### PR DESCRIPTION
This is a quick hack to verify that the 5.0 compat / random compat problems we have are caused by the direct mem mapping code.

So far I've had multiple independent confirmations that this resolves both new and old breakage.

This *must absolutely not* be merged in it's current state. I'll clean it up for r7 timeframe, then properly implement it for r8/r9.