### PR TITLE
pvr/vram: Bank bit seems to be fixed on 4M, even on 16M hardware

### DIFF
--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -195,11 +195,11 @@ u8 DYNACALL pvr_read_area1_8(u32 addr)
 
 u16 DYNACALL pvr_read_area1_16(u32 addr)
 {
-	return *(u16*)&vram[pvr_map32(addr)];
+	return *(u16*)&vram[pvr_map32(addr) & VRAM_MASK];
 }
 u32 DYNACALL pvr_read_area1_32(u32 addr)
 {
-	return *(u32*)&vram[pvr_map32(addr)];
+	return *(u32*)&vram[pvr_map32(addr) & VRAM_MASK];
 }
 
 //write
@@ -209,11 +209,11 @@ void DYNACALL pvr_write_area1_8(u32 addr,u8 data)
 }
 void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 {
-	*(u16*)&vram[pvr_map32(addr)]=data;
+	*(u16*)&vram[pvr_map32(addr) & VRAM_MASK]=data;
 }
 void DYNACALL pvr_write_area1_32(u32 addr,u32 data)
 {
-	*(u32*)&vram[pvr_map32(addr)]=data;
+	*(u32*)&vram[pvr_map32(addr) & VRAM_MASK] = data;
 }
 
 void TAWrite(u32 address,u32* data,u32 count)
@@ -277,33 +277,32 @@ void pvr_Reset(bool Manual)
 		vram.Zero();
 }
 
+#define VRAM_BANK_BIT 0x400000
 
 u32 pvr_map32(u32 offset32)
 {
 		//64b wide bus is achieved by interleaving the banks every 32 bits
-		//so bank is Address<<3
-		//bits <4 are <<1 to create space for bank num
-		//bank 0 is mapped at 400000 (32b offset) and after
-		const u32 bank_bit=VRAM_MASK-(VRAM_MASK/2);
-		const u32 static_bits=(VRAM_MASK-(bank_bit*2)+1)|3;
-		const u32 moved_bits=VRAM_MASK-static_bits-bank_bit;
+		const u32 bank_bit = VRAM_BANK_BIT;
+		const u32 static_bits = VRAM_MASK - (VRAM_BANK_BIT * 2 - 1);
+		const u32 offset_bits = VRAM_BANK_BIT - 1;
 
-		u32 bank=(offset32&bank_bit)/bank_bit*4;//bank will be used as upper offset too
-		u32 lv=offset32&static_bits; //these will survive
-		offset32&=moved_bits;
-		offset32<<=1;
-		//       |inbank offset    |       bank id        | lower 2 bits (not changed)
-		u32 rv=  offset32 + bank                  + lv;
- 
+		u32 bank = (offset32 & VRAM_BANK_BIT) / VRAM_BANK_BIT;
+
+		u32 rv = offset32 & static_bits;
+
+		rv |= (offset32 & offset_bits) * 8;
+
+		rv |= bank * 4;
+
 		return rv;
 }
 
 
 f32 vrf(u32 addr)
 {
-	return *(f32*)&vram[pvr_map32(addr)];
+	return *(f32*)&vram[pvr_map32(addr) & VRAM_MASK];
 }
 u32 vri(u32 addr)
 {
-	return *(u32*)&vram[pvr_map32(addr)];
+	return *(u32*)&vram[pvr_map32(addr) & VRAM_MASK];
 }

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -1541,11 +1541,13 @@ void FillBGP(TA_context* ctx)
 	bool PSVM=FPU_SHAD_SCALE.intesity_shadow!=0; //double parameters for volumes
 
 	//Get the strip base
-	u32 strip_base=(param_base + ISP_BACKGND_T.tag_address*4)&0x7FFFFF;	//this is *not* VRAM_MASK on purpose.It fixes naomi bios and quite a few naomi games
+	u32 strip_base=(param_base + ISP_BACKGND_T.tag_address*4);	//this is *not* VRAM_MASK on purpose.It fixes naomi bios and quite a few naomi games
 	//i have *no* idea why that happens, they manage to set the render target over there as well
 	//and that area is *not* written by the games (they instead write the params on 000000 instead of 800000)
 	//could be a h/w bug ? param_base is 400000 and tag is 100000*4
 	//Calculate the vertex size
+	//Update: Looks like I was handling the bank interleave wrong for 16 megs ram, could that be it?
+
 	u32 strip_vs=3 + ISP_BACKGND_T.skip;
 	u32 strip_vert_num=ISP_BACKGND_T.tag_offset;
 


### PR DESCRIPTION
This should fix some NAOMI issues, which don't quite apply (yet). Thanks to @inolen on irc for the long conversation about the issue, which made me realize where the old handling was wrong :dancers: 