### PR TITLE
sh4_opcodes: Fix printf arguments

### DIFF
--- a/core/hw/sh4/interpr/sh4_opcodes.cpp
+++ b/core/hw/sh4/interpr/sh4_opcodes.cpp
@@ -70,7 +70,7 @@ void cpu_iNimp(u32 op, const char* info)
 void cpu_iWarn(u32 op, const char* info)
 {
 	printf("Check opcode : %X : ", op);
-	printf(info);
+	printf("%s", info);
 	printf(" @ %X\n", curr_pc);
 }
 


### PR DESCRIPTION
This partly resolves #660 (needs to applied to linux-64 branch, too).