### PR TITLE
sh4_opcodes: Fix printf arguments (skmp/linux-x64 branch)

### DIFF
--- a/core/hw/sh4/interpr/sh4_opcodes.cpp
+++ b/core/hw/sh4/interpr/sh4_opcodes.cpp
@@ -62,7 +62,7 @@ void dofoo(sh4_opcode op)
 void cpu_iNimp(u32 op, const char* info)
 {
 	printf("\n\nUnimplemented opcode : %X : %X \n", op,next_pc);
-	printf(info);
+	printf("%s", info);
 	die("iNimp reached\n");
 	//sh4_cpu.Stop();
 }
@@ -70,7 +70,7 @@ void cpu_iNimp(u32 op, const char* info)
 void cpu_iWarn(u32 op, const char* info)
 {
 	printf("Check opcode : %X : ", op);
-	printf(info);
+	printf("%s", info);
 	printf(" @ %X\n", curr_pc);
 }
 


### PR DESCRIPTION
This resolves #660 (basically the changes from commit fb50c75 applied
to the 'skmp/linux-64' branch. As an alternative, puts() could be used
instead of prinf().