### PR TITLE
Linux version loads controller information from the configuration file

### DIFF
--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -4,7 +4,6 @@
 #include "maple_devs.h"
 #include "maple_cfg.h"
 
-#define HAS_VMU
 /*
 bus_x=0{p0=1{config};p1=2{config};config;}
 Plugins:
@@ -66,14 +65,26 @@ void mcfg_Create(MapleDeviceType type,u32 bus,u32 port)
 	MapleDevices[bus][port]=dev;
 }
 
-void mcfg_CreateDevices()
+void mcfg_CreateDevices(int id_controller, bool has_vmu_top, bool has_vmu_bottom)
 {
-	mcfg_Create(MDT_SegaController,0,5);
+	if (id_controller > 3)
+	{
+		printf("Error: tried to create controller %d. Only up to 4 controllers are supported\n", id_controller);
+		return;
+	} else {
+		printf("Creating controller %d\n", id_controller);
+	}
 
-	#ifdef HAS_VMU
-	mcfg_Create(MDT_SegaVMU,0,0);
-	mcfg_Create(MDT_SegaVMU,0,1);
-	#endif
+	mcfg_Create(MDT_SegaController,id_controller,5);
+
+	if (has_vmu_top)
+	{
+		mcfg_Create(MDT_SegaVMU,id_controller,0);
+	}
+	if (has_vmu_bottom)
+	{
+		mcfg_Create(MDT_SegaVMU,id_controller,1);
+	}
 }
 
 void mcfg_DestroyDevices()

--- a/core/hw/maple/maple_cfg.h
+++ b/core/hw/maple/maple_cfg.h
@@ -62,5 +62,5 @@ struct IMapleConfigMap
 	virtual ~IMapleConfigMap() {}
 };
 
-void mcfg_CreateDevices();
+void mcfg_CreateDevices(int id_controller = 0, bool has_vmu_top = true, bool has_vmu_bottom = true);
 void mcfg_DestroyDevices();

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -813,11 +813,11 @@ void os_DoEvents()
                     	{
 	                        if (e.type == KeyPress)
                         	{    
-	                            dc_pads[port].axis_lt = 255;
+	                            dc_pads[port].axis_rt = 255;
                         	}
                         	else if (e.type == KeyRelease)
                         	{
-	                            dc_pads[port].axis_lt = 0;
+	                            dc_pads[port].axis_rt = 0;
                         	}
                         	else
                         	{

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -527,6 +527,10 @@ bool HandleJoystick(u32 port)
   			// Axis handling
   			case JS_EVENT_AXIS:
   				
+  				if (id == 0)
+  				{
+  					printf("Event with value %d\n", signed_value);
+  				}
   				// Direction stick
   				if(id == js_maps[port].id_axis_x)
   				{
@@ -718,6 +722,10 @@ void os_DoEvents()
                     
 					for (int port = 0; port <= 3; ++port)
 					{
+						if (js_maps[port].js.file_descriptor > 0)
+						{
+							continue;
+						}
                     	//Detect up press
                     	if(e.xkey.keycode == kb_maps[port].key_axis_up)
                     	{
@@ -839,6 +847,10 @@ void os_DoEvents()
         /* Check analogue control states (up/down) */
         for (int port = 0; port <= 3; ++port)
 		{
+			if (js_maps[port].js.file_descriptor > 0)
+			{
+				continue;
+			}
 
 			// X axis
 	        if((ana_up[port] == true) && (ana_down[port] == false))

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -502,10 +502,10 @@ return;
 	// HandleJoystick(port);
 	// HandleKb(port);
 	kcode[port]= x11_dc_buttons[port];
-	joyx[0] = temp_joyx[port];
-    joyy[0] = temp_joyy[port];
-    lt[0] = temp_lt[port];
-    rt[0] = temp_rt[port];	
+	joyx[port] = temp_joyx[port];
+    joyy[port] = temp_joyy[port];
+    lt[port] = temp_lt[port];
+    rt[port] = temp_rt[port];	
 	return;
 #endif
 	for(;;)
@@ -558,171 +558,174 @@ void os_DoEvents()
 {
 
 	#if defined(SUPPORT_X11)
-	for (int port = 0; port <=3; ++port)
-	{
- 		static bool ana_up = false;
-		static bool ana_down = false;
-		static bool ana_left = false;
-		static bool ana_right = false;    
-		// int x11_dc_buttons = 0xFFFF;
-    
-    	if (x11_win) {
-			//Handle X11
-			XEvent e;
-			if(XCheckWindowEvent((Display*)x11_disp, (Window)x11_win, KeyPressMask | KeyReleaseMask, &e)){
-				switch(e.type){
+	static bool ana_up[4] = {false, false, false, false};
+	static bool ana_down[4] = {false, false, false, false};
+	static bool ana_left[4] = {false, false, false, false};
+	static bool ana_right[4] = {false, false, false, false};
+	// int x11_dc_buttons = 0xFFFF;
 
-					case KeyPress:
-					case KeyRelease:
+	if (x11_win) {
+		//Handle X11
+		XEvent e;
+		if(XCheckWindowEvent((Display*)x11_disp, (Window)x11_win, KeyPressMask | KeyReleaseMask, &e)){
+			switch(e.type){
+
+				case KeyPress:
+				case KeyRelease:
+				{
+                    
+					for (int port = 0; port <= 3; ++port)
 					{
-	                    
-	                    //Detect up press
-	                    if(e.xkey.keycode == kb_maps[port].XANA_UP)
-	                    {
+                    	//Detect up press
+                    	if(e.xkey.keycode == kb_maps[port].XANA_UP)
+                    	{
 	                        if(e.type == KeyPress)
-	                        {    
-	                	        ana_up = true;
-	                        }
-	                        else if(e.type == KeyRelease)
-	                        {
-	                            ana_up = false;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    } else {
+                        	{    
+	                	        ana_up[port] = true;
+                        	}
+                        	else if(e.type == KeyRelease)
+                        	{
+	                            ana_up[port] = false;
+                        	}
+                        	else
+                        	{
+                        	}
+                    	} else {
 
-	                    }
-	                    
-	                    //Detect down Press
-	                    if(e.xkey.keycode == kb_maps[port].XANA_DOWN)
-	                    {
+                    	}
+                    
+                    	//Detect down Press
+                    	if(e.xkey.keycode == kb_maps[port].XANA_DOWN)
+                    	{
 	                        if(e.type == KeyPress)
-	                        {    
-	                            ana_down = true;
-	                        }
-	                        else if(e.type == KeyRelease)
-	                        {
-	                            ana_down = false;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    }
-	  
-	                    //Detect left press
-	                    if(e.xkey.keycode == kb_maps[port].XANA_LEFT)
-	                    {
+                        	{    
+	                            ana_down[port] = true;
+                        	}
+                        	else if(e.type == KeyRelease)
+                        	{
+	                            ana_down[port] = false;
+                        	}
+                        	else
+                        	{
+                        	}
+                    	}
+  
+                    	//Detect left press
+                    	if(e.xkey.keycode == kb_maps[port].XANA_LEFT)
+                    	{
 	                        if(e.type == KeyPress)
-	                        {    
-	                            ana_left = true;
-	                        }
-	                        else if(e.type == KeyRelease)
-	                        {
-	                            ana_left = false;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    } 
-	                        
-	                    //Detect right Press
-	                    if(e.xkey.keycode == kb_maps[port].XANA_RIGHT)
-	                    {
+                        	{    
+	                            ana_left[port] = true;
+                        	}
+                        	else if(e.type == KeyRelease)
+                        	{
+	                            ana_left[port] = false;
+                        	}
+                        	else
+                        	{
+                        	}
+                    	} 
+                        
+                    	//Detect right Press
+                    	if(e.xkey.keycode == kb_maps[port].XANA_RIGHT)
+                    	{
 	                        if(e.type == KeyPress)
-	                        {    
-	                            ana_right = true;
-	                        }
-	                        else if(e.type == KeyRelease)
-	                        {
-	                            ana_right = false;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    } 
-	                        
-	                    //detect LT press
-	                    if (e.xkey.keycode == kb_maps[port].XANA_LT)
-	                    {
+                        	{    
+	                            ana_right[port] = true;
+                        	}
+                        	else if(e.type == KeyRelease)
+                        	{
+	                            ana_right[port] = false;
+                        	}
+                        	else
+                        	{
+                        	}
+                    	}
+                        
+                    	//detect LT press
+                    	if (e.xkey.keycode == kb_maps[port].XANA_LT)
+                    	{
 	                        if (e.type == KeyPress)
-	                        {    
+                        	{    
 	                            temp_lt[port] = 255;
-	                        }
-	                        else if (e.type == KeyRelease)
-	                        {
+                        	}
+                        	else if (e.type == KeyRelease)
+                        	{
 	                            temp_lt[port] = 0;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    }
-	                        
-	                    //detect RT press
-	                    if (e.xkey.keycode == kb_maps[port].XANA_RT)
-	                    {
+                        	}
+                        	else
+                        	{
+                        	}
+                    	}
+                        
+                    	//detect RT press
+                    	if (e.xkey.keycode == kb_maps[port].XANA_RT)
+                    	{
 	                        if (e.type == KeyPress)
-	                        {    
+                        	{    
 	                            temp_rt[port] = 255;
-	                        }
-	                        else if (e.type == KeyRelease)
-	                        {
+                        	}
+                        	else if (e.type == KeyRelease)
+                        	{
 	                            temp_rt[port] = 0;
-	                        }
-	                        else
-	                        {
-	                        }
-	                    }
-	                        
+                        	}
+                        	else
+                        	{
+                        	}
+                    	}
+   
 						int dc_key = kb_maps[port].keymap[e.xkey.keycode];
 
 						if (e.type == KeyPress)
 							x11_dc_buttons[port] &= ~dc_key;
 						else
 							x11_dc_buttons[port] |= dc_key;
-
 					}
-					break;
-
-					default:
-					{
-						printf("KEYRELEASE\n");
-					}
-					break;
 
 				}
-	        }
-	            
-	        /* Check analogue control states (up/down) */
-	        if((ana_up == true) && (ana_down == false))
-	        {
+				break;
+
+				default:
+				{
+					printf("KEYRELEASE\n");
+				}
+				break;
+
+			}
+        }
+            
+        /* Check analogue control states (up/down) */
+        for (int port = 0; port <= 3; ++port)
+		{
+	        if((ana_up[port] == true) && (ana_down[port] == false))
+        	{
 	            temp_joyy[port] = -127;
-	        }
-	        else if((ana_up == false) && (ana_down == true))
-	        {
+        	}
+        	else if((ana_up[port] == false) && (ana_down[port] == true))
+        	{
 	            temp_joyy[port] = 127;
-	        }
-	        else
-	        {
+        	}
+        	else
+        	{
 	            /* Either both pressed simultaniously or neither pressed */
-	            temp_joyy[port] = 0;
-	        }
+            	temp_joyy[port] = 0;
+        	}
 	            
-	        /* Check analogue control states (left/right) */
-	        if((ana_left == true) && (ana_right == false))
-	        {
+        	/* Check analogue control states (left/right) */
+        	if((ana_left[port] == true) && (ana_right[port] == false))
+        	{
 	            temp_joyx[port] = -127;
-	        }
-	        else if((ana_left == false) && (ana_right == true))
-	        {
+        	}
+        	else if((ana_left[port] == false) && (ana_right[port] == true))
+        	{
 	            temp_joyx[port] = 127;
-	        }
-	        else
-	        {
+        	}
+        	else
+        	{
 	            /* Either both pressed simultaniously or neither pressed */
-	            temp_joyx[port] = 0;
-	        }        
-		}
+            	temp_joyx[port] = 0;
+        	}        
+        }
 	}
     #endif
 }

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -526,11 +526,6 @@ bool HandleJoystick(u32 port)
   		{
   			// Axis handling
   			case JS_EVENT_AXIS:
-  				
-  				if (id == 0)
-  				{
-  					printf("Event with value %d\n", signed_value);
-  				}
   				// Direction stick
   				if(id == js_maps[port].id_axis_x)
   				{

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -611,6 +611,7 @@ void UpdateInputState(u32 port)
 	HandleKb(port);
 return;
 #elif defined(SUPPORT_X11)
+	kcode[port] = 0xFFFF;
 	if (!HandleJoystick(port))
 	{
 		HandleKb(port);
@@ -619,6 +620,8 @@ return;
 	    joyy[port] = temp_joyy[port];
 	    lt[port] = temp_lt[port];
 	    rt[port] = temp_rt[port];	
+	} else {
+
 	}
 	return;
 #endif

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -209,8 +209,8 @@ int dc_init(int argc,wchar* argv[])
 	if (cfgOpen())
 	{
 		// Creation of first controller
-		// By default: present with two VMUs
-		if (cfgLoadInt("control1","present",1)==1)
+		// By default: plugged with two VMUs
+		if (cfgLoadInt("control1","plugged",1)==1)
 		{
 			bool vmu_top = cfgLoadInt("control1","vmu.top",1)==1;
 			bool vmu_bottom = cfgLoadInt("control1","vmu.bottom",1)==1;
@@ -219,21 +219,21 @@ int dc_init(int argc,wchar* argv[])
 
 		// Creation of remaining controllers
 		// By default: not present with no VMU
-		if (cfgLoadInt("control2","present",0)==1)
+		if (cfgLoadInt("control2","plugged",0)==1)
 		{
 			bool vmu_top = cfgLoadInt("control2","vmu.top",0)==1;
 			bool vmu_bottom = cfgLoadInt("control2","vmu.bottom",0)==1;
 			mcfg_CreateDevices(1, vmu_top, vmu_bottom);
 		}
 
-		if (cfgLoadInt("control3","present",0)==1)
+		if (cfgLoadInt("control3","plugged",0)==1)
 		{
 			bool vmu_top = cfgLoadInt("control3","vmu.top",0)==1;
 			bool vmu_bottom = cfgLoadInt("control3","vmu.bottom",0)==1;
 			mcfg_CreateDevices(2, vmu_top, vmu_bottom);
 		}
 
-		if (cfgLoadInt("control4","present",0)==1)
+		if (cfgLoadInt("control4","plugged",0)==1)
 		{
 			bool vmu_top = cfgLoadInt("control4","vmu.top",0)==1;
 			bool vmu_bottom = cfgLoadInt("control4","vmu.bottom",0)==1;

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -206,7 +206,40 @@ int dc_init(int argc,wchar* argv[])
 	
 	mem_map_default();
 
-	mcfg_CreateDevices();
+	if (cfgOpen())
+	{
+		// Creation of first controller
+		// By default: present with two VMUs
+		if (cfgLoadInt("control1","present",1)==1)
+		{
+			bool vmu_top = cfgLoadInt("control1","vmu.top",1)==1;
+			bool vmu_bottom = cfgLoadInt("control1","vmu.bottom",1)==1;
+			mcfg_CreateDevices(0, vmu_top, vmu_bottom);
+		}
+
+		// Creation of remaining controllers
+		// By default: not present with no VMU
+		if (cfgLoadInt("control2","present",0)==1)
+		{
+			bool vmu_top = cfgLoadInt("control2","vmu.top",0)==1;
+			bool vmu_bottom = cfgLoadInt("control2","vmu.bottom",0)==1;
+			mcfg_CreateDevices(1, vmu_top, vmu_bottom);
+		}
+
+		if (cfgLoadInt("control3","present",0)==1)
+		{
+			bool vmu_top = cfgLoadInt("control3","vmu.top",0)==1;
+			bool vmu_bottom = cfgLoadInt("control3","vmu.bottom",0)==1;
+			mcfg_CreateDevices(2, vmu_top, vmu_bottom);
+		}
+
+		if (cfgLoadInt("control4","present",0)==1)
+		{
+			bool vmu_top = cfgLoadInt("control4","vmu.top",0)==1;
+			bool vmu_bottom = cfgLoadInt("control4","vmu.bottom",0)==1;
+			mcfg_CreateDevices(3, vmu_top, vmu_bottom);
+		}
+	}
 
 	plugins_Reset(false);
 	mem_Reset(false);


### PR DESCRIPTION
For all versions:
 - The virtual controllers and VMU plugged are now read from the config file. If nothing is specified in the configuration file, the first controller with two VMUs are plugged by default.

For linux version:
 - Keyboard binding for each controller is read from the configuration file, using X11 keycodes
 - PC Controller mapping for each dreamcast controller is read from the configuration file as well

I have tested my code with two players using 1 keyboard for two players, 1 keyboard + 1 controller and 2 controllers, and everythings was working properly. Though I could not try using twice the same controller (which would then appear having the same name), but I think it should not be an issue.

Don't hesitate to tell me if you want me to change things before accepting the pull request.