### PR TITLE
Fix shm_open on the rpi

### DIFF
--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -550,7 +550,7 @@ error:
 		//shm is borken on the rapi
 		//using a file is slower, but works
 		//file in tmpfs would be better?
-		fd = -1;shm_open("/dcnzorz_mem", O_CREAT | O_EXCL | O_RDWR,S_IREAD | S_IWRITE);
+		fd = -1;fd = shm_open("/dcnzorz_mem", O_CREAT | O_EXCL | O_RDWR,S_IREAD | S_IWRITE);
 		if (fd != -1) { verify(ftruncate(fd,RAM_SIZE + VRAM_SIZE +ARAM_SIZE)==0); }
 		shm_unlink("/dcnzorz_mem");
 		if (fd==-1)


### PR DESCRIPTION
Wasn't actually putting the returncode of shm_open to fd

This code could do with a cleanup though -  as it doesn't need to fallback anymore is the fallback code needed ? fd doesn't need to be initialised either. Not sure if this branch is still in development or not really, so I'll leave that to you. Cheers.