### PR TITLE
maple: Gracefully fail if vmu cannot be written

### DIFF
--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -286,8 +286,12 @@ struct maple_sega_vmu: maple_base
 		{
 			printf("Unable to open VMU save file \"%s\", creating new file\n",apath.c_str());
 			file=fopen(apath.c_str(),"wb");
-			fwrite(flash_data, sizeof(flash_data), 1, file);
-			fseek(file,0,SEEK_SET);
+			if (file) {
+				fwrite(flash_data, sizeof(flash_data), 1, file);
+				fseek(file,0,SEEK_SET);
+			} else {
+				printf("Unable to create vmu\n");
+			}
 		}
 
 		if (!file)


### PR DESCRIPTION
This makes it possible to work on a read-only fs