### PR TITLE
hw/sh4/dyna/driver.cpp: Fix pointer size on 64 bit arch

### DIFF
--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -309,7 +309,7 @@ void* DYNACALL rdv_LinkBlock(u8* code,u32 dpc)
 		rbi=bm_GetStaleBlock(code);
 	}
 	
-	verify((int)rbi);
+	verify((size_t)rbi);
 
 	u32 bcls=BET_GET_CLS(rbi->BlockType);
 


### PR DESCRIPTION
On AMD64/x86_64 systems, `sizeof(int)` is 4 bytes but `sizeof(int*)` is 8 bytes.

If you try to compile this with `clang`, you'll get:

```
../../core/hw/sh4/dyna/driver.cpp:311:9: error: cast from pointer to smaller type 'int' loses information
        verify((int)rbi);
               ^~~~~~~~
../../core/types.h:521:23: note: expanded from macro 'verify'
#define verify(x) if((x)==false){ msgboxf("Verify Failed  : " #x "\n in %s -> %s : %d \n",MBX_ICONERROR,(__FUNCTION__),(__FILE__),__LINE__); dbgbreak;}
```