### PR TITLE
Add ODROID-C1/C1+/X/X2/U2/U3/XU/XU3/XU4 support

### DIFF
--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -39,6 +39,8 @@ ifeq (,$(platform))
             platform = beagle
         else ifneq (,$(findstring Pandora,$(HARDWARE)))
             platform = pandora
+        else ifneq (,$(findstring ODROIDC,$(HARDWARE)))
+            platform = odroidc1
         else
             $(error Unsupported Hardware)
         endif
@@ -106,6 +108,14 @@ else ifneq (,$(findstring pandora,$(platform)))
     MFLAGS +== -marm -march=armv7-a -mtune=cortex-a8 -mfpu=neon -mfloat-abi=softfp -funroll-loops -fpermissive
     ASFLAGS += -march=armv7-a -mfpu=neon -mfloat-abi=softfp
     CFLAGS += -D TARGET_PANDORA  -D WEIRD_SLOWNESS -fsingle-precision-constant
+
+# ODROID-C1
+else ifneq (,$(findstring odroidc1,$(platform)))
+    AS=${CC_PREFIX}gcc
+    MFLAGS += -marm -march=armv7-a -mtune=cortex-a5 -mfpu=neon -mfloat-abi=hard -funroll-loops
+    ASFLAGS += -march=armv7-a -mfpu=neon -mfloat-abi=hard
+    CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP
+    USE_GLES := 1
 
 # GCW Zero
 else ifneq (,$(findstring gcwz,$(platform)))

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -41,6 +41,18 @@ ifeq (,$(platform))
             platform = pandora
         else ifneq (,$(findstring ODROIDC,$(HARDWARE)))
             platform = odroidc1
+        else ifneq (,$(findstring ODROID-XU3,$(HARDWARE)))
+            platform = odroidxu3
+        else ifneq (,$(findstring ODROIDXU,$(HARDWARE)))
+            platform = odroidxu
+        else ifneq (,$(findstring ODROIDX2,$(HARDWARE)))
+            platform = odroidx2
+        else ifneq (,$(findstring ODROIDX,$(HARDWARE)))
+            platform = odroidx
+        else ifneq (,$(findstring ODROID-U2/U3,$(HARDWARE)))
+            platform = odroidu2
+        else ifneq (,$(findstring ODROIDU2,$(HARDWARE)))
+            platform = odroidu2
         else
             $(error Unsupported Hardware)
         endif
@@ -109,13 +121,34 @@ else ifneq (,$(findstring pandora,$(platform)))
     ASFLAGS += -march=armv7-a -mfpu=neon -mfloat-abi=softfp
     CFLAGS += -D TARGET_PANDORA  -D WEIRD_SLOWNESS -fsingle-precision-constant
 
-# ODROID-C1
-else ifneq (,$(findstring odroidc1,$(platform)))
+# ODROIDs
+else ifneq (,$(findstring odroid,$(platform)))
     AS=${CC_PREFIX}gcc
-    MFLAGS += -marm -march=armv7-a -mtune=cortex-a5 -mfpu=neon -mfloat-abi=hard -funroll-loops
-    ASFLAGS += -march=armv7-a -mfpu=neon -mfloat-abi=hard
-    CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP
+    MFLAGS += -marm -mfpu=neon -mfloat-abi=hard -funroll-loops
+    ASFLAGS += -mfpu=neon -mfloat-abi=hard
+    CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant
     USE_GLES := 1
+
+    # ODROID-XU3, -XU3 Lite & -XU4
+    ifneq (,$(findstring odroidxu3,$(platform)))
+        MFLAGS += -march=armv7ve -mtune=cortex-a15.cortex-a7
+        ASFLAGS += -march=armv7ve
+
+    # Other ODROIDs
+    else
+        MFLAGS += -march=armv7-a
+        ASFLAGS += -march=armv7-a
+
+        # ODROID-C1 & -C1+
+        ifneq (,$(findstring odroidc1,$(platform)))
+            MFLAGS += -mtune=cortex-a5
+
+        # ODROID-U2, -U3, -X & -X2
+        else
+            MFLAGS += -mtune=cortex-a9
+
+        endif
+    endif
 
 # GCW Zero
 else ifneq (,$(findstring gcwz,$(platform)))


### PR DESCRIPTION
This adds support for the ODROID-C1/C1+/X/X2/U2/U3/XU/XU3/XU4 single board computers by Hardkernel.

Makes #708 obsolete.

This is a follow-up PR to #705. Unlike #605, this PR just adds some Makefile definitions (no code changes). I compiled and tested on an ODROID-C1 and everything seems to work as expected. ~~**EDIT:** Strange, I rebased and currently get some strange errors:~~ **FIXED**

```
In file included from ../../core/hw/sh4/dyna/shil.cpp:1012:0:
../../core/hw/sh4/dyna/shil_canonical.h: In static member function 'static void shil_opcl_fipr::compile(shil_opcode*)':
../../core/hw/sh4/dyna/shil_canonical.h:14:19: error: 'fipr_asm' is not a class or namespace
 #define fipr_impl fipr_asm
                   ^
../../core/hw/sh4/dyna/shil_canonical.h:56:87: note: in definition of macro 'shil_compile'
  #define shil_compile(code) static void compile(shil_opcode* op) { ngen_CC_Start(op); code ngen_CC_Finish(op); }
                                                                                       ^
../../core/hw/sh4/dyna/shil_canonical.h:54:21: note: in expansion of macro 'shil_cf_ext'
  #define shil_cf(x) shil_cf_ext(x::impl)
                     ^
../../core/hw/sh4/dyna/shil_canonical.h:869:2: note: in expansion of macro 'shil_cf'
  shil_cf(fipr_impl);
  ^
../../core/hw/sh4/dyna/shil_canonical.h:869:10: note: in expansion of macro 'fipr_impl'
  shil_cf(fipr_impl);
          ^
../../core/hw/sh4/dyna/shil_canonical.h: In static member function 'static void shil_opcl_ftrv::compile(shil_opcode*)':
../../core/hw/sh4/dyna/shil_canonical.h:13:19: error: 'ftrv_asm' is not a class or namespace
 #define ftrv_impl ftrv_asm
                   ^
../../core/hw/sh4/dyna/shil_canonical.h:56:87: note: in definition of macro 'shil_compile'
  #define shil_compile(code) static void compile(shil_opcode* op) { ngen_CC_Start(op); code ngen_CC_Finish(op); }
                                                                                       ^
../../core/hw/sh4/dyna/shil_canonical.h:54:21: note: in expansion of macro 'shil_cf_ext'
  #define shil_cf(x) shil_cf_ext(x::impl)
                     ^
../../core/hw/sh4/dyna/shil_canonical.h:918:2: note: in expansion of macro 'shil_cf'
  shil_cf(ftrv_impl);
  ^
../../core/hw/sh4/dyna/shil_canonical.h:918:10: note: in expansion of macro 'ftrv_impl'
  shil_cf(ftrv_impl);
          ^
Makefile:250: recipe for target 'obj-odroidc1/hw/sh4/dyna/shil.build_obj' failed
make: *** [obj-odroidc1/hw/sh4/dyna/shil.build_obj] Error 1
```

