### PR TITLE
Fix Linux Makefile

### DIFF
--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -71,7 +71,7 @@ ifneq (,$(findstring x86,$(platform)))
     NOT_ARM := 1
     USE_X11 := 1
     MFLAGS += -m32
-    ASFLAGS += -32
+    ASFLAGS += --32
     LDFLAGS += -m32
     CFLAGS += -m32 -D TARGET_LINUX_x86 -D TARGET_NO_AREC -fsingle-precision-constant
     CXXFLAGS += -fno-exceptions
@@ -259,7 +259,7 @@ obj-$(platform)/%.build_obj : $(RZDCY_SRC_DIR)/%.c
 
 obj-$(platform)/%.build_obj : $(RZDCY_SRC_DIR)/%.S
 	mkdir -p $(dir $@)	
-	$(AS) $(ASFLAGS) $(INCS) $(CFLAGS) $< -o $@
+	$(AS) $(ASFLAGS) $(INCS) $< -o $@
 
 clean:
 	rm $(OBJECTS) $(EXECUTABLE) -f


### PR DESCRIPTION
`as` does not recognize `-m32`