### PR TITLE
Remove unnecessary includes

### DIFF
--- a/core/hw/pvr/drkPvr.cpp
+++ b/core/hw/pvr/drkPvr.cpp
@@ -16,7 +16,6 @@
 #include "pvr_regs.h"
 #include "pvr_mem.h"
 #include "Renderer_if.h"
-#include <algorithm>
 
 
 void libPvr_LockedBlockWrite (vram_block* block,u32 addr)

--- a/core/reios/descrambl.cpp
+++ b/core/reios/descrambl.cpp
@@ -7,7 +7,6 @@
 */
 
 #include "descrambl.h"
-#include <algorithm>
 
 #define MAXCHUNK (2048*1024)
 


### PR DESCRIPTION
Are these needed? I was able to compile without them.