### PR TITLE
msvc: Update sln files to use "x86" instead of "win32" for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: git-{branch}-{build}
+configuration: Debug
+platform:
+- x86
+- x64
+build:
+  project: shell/reicast.sln
+  parallel: true
+  verbosity: minimal

--- a/shell/reicast.sln
+++ b/shell/reicast.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "reicast", "reicast.vcxproj", "{58B14048-EACB-4780-8B1E-9C84C2C30A8E}"
 EndProject
@@ -12,20 +12,19 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Release|Win32 = Release|Win32
+		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Debug|Win32.ActiveCfg = Slow|Win32
-		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Debug|Win32.Build.0 = Slow|Win32
 		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Debug|x64.ActiveCfg = Slow|x64
 		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Debug|x64.Build.0 = Slow|x64
-		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|Win32.ActiveCfg = Fast|Win32
-		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|Win32.Build.0 = Fast|Win32
+		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Debug|x86.ActiveCfg = Slow|Win32
 		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|x64.ActiveCfg = Fast|x64
 		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|x64.Build.0 = Fast|x64
+		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|x86.ActiveCfg = Fast|Win32
+		{58B14048-EACB-4780-8B1E-9C84C2C30A8E}.Release|x86.Build.0 = Fast|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Getting everything working for appveyor, building all 4 configurations