### PR TITLE
Add a generic 32-bit ARM rule.

### DIFF
--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -56,7 +56,7 @@ ifeq (,$(platform))
         else ifneq (,$(findstring ODROIDU2,$(HARDWARE)))
             platform = odroidu2
         else
-            platform = arm
+            platform = armv7h
         endif
     else ifneq (,$(findstring mips,$(ARCH)))
         platform = gcwz
@@ -86,8 +86,8 @@ else ifneq (,$(findstring x64,$(platform)))
     CFLAGS += -D TARGET_LINUX_x64 -D TARGET_NO_AREC -fsingle-precision-constant
     CXXFLAGS += -fexceptions
 
-# Generic 32 bit ARM (a.k.a. ARMhf/ARMv7)
-else ifneq (,$(findstring arm,$(platform)))
+# Generic 32 bit ARMhf (a.k.a. ARMv7h)
+else ifneq (,$(findstring armv7h,$(platform)))
     MFLAGS += -marm -mfpu=neon -mfloat-abi=hard -funroll-loops -march=armv7-a
     ASFLAGS += -mfpu=neon -mfloat-abi=hard -march=armv7-a
     CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -88,11 +88,10 @@ else ifneq (,$(findstring x64,$(platform)))
 
 # Generic 32 bit ARMhf (a.k.a. ARMv7h)
 else ifneq (,$(findstring armv7h,$(platform)))
-    MFLAGS += -marm -mfpu=neon -mfloat-abi=hard -funroll-loops -march=armv7-a
-    ASFLAGS += -mfpu=neon -mfloat-abi=hard -march=armv7-a
+    MFLAGS += -marm -mfloat-abi=hard -march=armv7-a -funroll-loops
+    ASFLAGS += -mfloat-abi=hard -march=armv7-a
     CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant
     USE_GLES := 1
-    USE_X11 := 1
 
 # LinCPP
 else ifneq (,$(findstring lincpp,$(platform)))

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -56,7 +56,7 @@ ifeq (,$(platform))
         else ifneq (,$(findstring ODROIDU2,$(HARDWARE)))
             platform = odroidu2
         else
-            $(error Unsupported Hardware)
+            platform = arm
         endif
     else ifneq (,$(findstring mips,$(ARCH)))
         platform = gcwz
@@ -85,6 +85,14 @@ else ifneq (,$(findstring x64,$(platform)))
     USE_X11 := 1
     CFLAGS += -D TARGET_LINUX_x64 -D TARGET_NO_AREC -fsingle-precision-constant
     CXXFLAGS += -fexceptions
+
+# Generic 32 bit ARM (a.k.a. ARMhf/ARMv7)
+else ifneq (,$(findstring arm,$(platform)))
+    MFLAGS += -marm -mfpu=neon -mfloat-abi=hard -funroll-loops -march=armv7-a
+    ASFLAGS += -mfpu=neon -mfloat-abi=hard -march=armv7-a
+    CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant
+    USE_GLES := 1
+    USE_X11 := 1
 
 # LinCPP
 else ifneq (,$(findstring lincpp,$(platform)))

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -90,6 +90,10 @@ else ifneq (,$(findstring x64,$(platform)))
 else ifneq (,$(findstring armv7h,$(platform)))
     MFLAGS += -marm -mfloat-abi=hard -march=armv7-a -funroll-loops
     ASFLAGS += -mfloat-abi=hard -march=armv7-a
+    ifneq (,$(findstring neon,$(platform)))
+        MFLAGS += -mfpu=neon
+        ASFLAGS += -mfpu=neon
+    endif
     CFLAGS += -D TARGET_BEAGLE -D TARGET_LINUX_ARMELv7 -DARM_HARDFP -fsingle-precision-constant
     USE_GLES := 1
 


### PR DESCRIPTION
It can be useful in places like launchpad farm.