### PR TITLE
nulldc: Remove some hardcoded values

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -44,9 +44,6 @@ int GetFile(char *szFileName, char *szParse=0,u32 flags=0)
 	cfgLoadStr("config","image",szFileName,"null");
 	if (strcmp(szFileName,"null")==0)
 	{
-#if defined(OMAP4)
-		strcpy(szFileName,GetPath("/gdimage/crazy_taxi.chd").c_str());
-#else
 	#if HOST_OS==OS_WINDOWS
 		OPENFILENAME ofn;
 		ZeroMemory( &ofn , sizeof( ofn));
@@ -67,18 +64,9 @@ int GetFile(char *szFileName, char *szParse=0,u32 flags=0)
 			//already there
 			//strcpy(szFileName,ofn.lpstrFile);
 		}
-	#else
-		strcpy(szFileName,GetPath("/game.chd").c_str());
 	#endif
-#endif
 	}
 
-	if (strcmp(szFileName,"hardpath")==0)
-	{
-		strcpy(szFileName,"D:\\DC\\shenmue.chd");
-	}
-
-	
 	return 1; 
 }
 


### PR DESCRIPTION
According to the search function, `OMAP4` isn't set anywhere, so this shouldn't be a problem.

The other stuff also doesn't belong there IMHO. Guess this was testing code that hasn't been removed yet.