### PR TITLE
Introduce separate config/data dirs (user & system wide)

### DIFF
--- a/core/cfg/cfg.cpp
+++ b/core/cfg/cfg.cpp
@@ -78,9 +78,11 @@ void  cfgSaveStr(const wchar * Section, const wchar * Key, const wchar * String)
 
 bool cfgOpen()
 {
-	cfgPath=get_config_path("/emu.cfg");
-	FILE* cfgfile = fopen(cfgPath.c_str(),"r");
+	const char* filename = "/emu.cfg";
+	string config_path_read = get_readonly_config_path(filename);
+	cfgPath = get_writable_config_path(filename);
 
+	FILE* cfgfile = fopen(config_path_read.c_str(),"r");
 	if(cfgfile != NULL) {
 		cfgdb.parse(cfgfile);
 		fclose(cfgfile);
@@ -89,8 +91,8 @@ bool cfgOpen()
 	{
 		// Config file can't be opened
 		int error_code = errno;
-		printf("Warning: Unable to open the config file '%s' for reading (%s)\n", cfgPath.c_str(), strerror(error_code));
-		if (error_code == ENOENT)
+		printf("Warning: Unable to open the config file '%s' for reading (%s)\n", config_path_read.c_str(), strerror(error_code));
+		if (error_code == ENOENT || cfgPath != config_path_read)
 		{
 			// Config file didn't exist
 			printf("Creating new empty config file at '%s'\n", cfgPath.c_str());

--- a/core/cfg/cfg.cpp
+++ b/core/cfg/cfg.cpp
@@ -78,7 +78,7 @@ void  cfgSaveStr(const wchar * Section, const wchar * Key, const wchar * String)
 
 bool cfgOpen()
 {
-	cfgPath=GetPath("/emu.cfg");
+	cfgPath=get_config_path("/emu.cfg");
 	FILE* cfgfile = fopen(cfgPath.c_str(),"r");
 
 	if(cfgfile != NULL) {

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -277,7 +277,7 @@ struct maple_sega_vmu: maple_base
 		memset(lcd_data,0,sizeof(lcd_data));
 		wchar tempy[512];
 		sprintf(tempy,"/vmu_save_%s.bin",logical_port);
-		string apath=GetPath(tempy);
+		string apath=get_data_path(tempy);
 
 		file=fopen(apath.c_str(),"rb+");
 		if (!file)

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -277,7 +277,7 @@ struct maple_sega_vmu: maple_base
 		memset(lcd_data,0,sizeof(lcd_data));
 		wchar tempy[512];
 		sprintf(tempy,"/vmu_save_%s.bin",logical_port);
-		string apath=get_data_path(tempy);
+		string apath=get_writable_data_path(tempy);
 
 		file=fopen(apath.c_str(),"rb+");
 		if (!file)

--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -580,7 +580,7 @@ error:
 	{
         
 #if HOST_OS == OS_DARWIN
-		string path = get_data_path("/dcnzorz_mem");
+		string path = get_writable_data_path("/dcnzorz_mem");
         fd = open(path.c_str(),O_CREAT|O_RDWR|O_TRUNC,S_IRWXU|S_IRWXG|S_IRWXO);
         unlink(path.c_str());
         verify(ftruncate(fd,RAM_SIZE + VRAM_SIZE +ARAM_SIZE)==0);

--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -580,7 +580,7 @@ error:
 	{
         
 #if HOST_OS == OS_DARWIN
-        string path = GetPath("/dcnzorz_mem");
+		string path = get_data_path("/dcnzorz_mem");
         fd = open(path.c_str(),O_CREAT|O_RDWR|O_TRUNC,S_IRWXU|S_IRWXG|S_IRWXO);
         unlink(path.c_str());
         verify(ftruncate(fd,RAM_SIZE + VRAM_SIZE +ARAM_SIZE)==0);

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -607,7 +607,7 @@ void print_blocks()
 
 	if (print_stats)
 	{
-		f=fopen(GetPath("/blkmap.lst").c_str(),"w");
+		f=fopen(get_data_path("/blkmap.lst").c_str(),"w");
 		print_stats=0;
 
 		printf("Writing blocks to %p\n",f);

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -607,7 +607,7 @@ void print_blocks()
 
 	if (print_stats)
 	{
-		f=fopen(get_data_path("/blkmap.lst").c_str(),"w");
+		f=fopen(get_writable_data_path("/blkmap.lst").c_str(),"w");
 		print_stats=0;
 
 		printf("Writing blocks to %p\n",f);

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -54,7 +54,7 @@ void emit_WriteCodeCache()
 {
 	wchar path[512];
 	sprintf(path,"/code_cache_%8p.bin",CodeCache);
-	string pt2=get_data_path(path);
+	string pt2=get_writable_data_path(path);
 	printf("Writing code cache to %s\n",pt2.c_str());
 	FILE*f=fopen(pt2.c_str(),"wb");
 	if (f)

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -54,7 +54,7 @@ void emit_WriteCodeCache()
 {
 	wchar path[512];
 	sprintf(path,"/code_cache_%8p.bin",CodeCache);
-	string pt2=GetPath(path);
+	string pt2=get_data_path(path);
 	printf("Writing code cache to %s\n",pt2.c_str());
 	FILE*f=fopen(pt2.c_str(),"wb");
 	if (f)

--- a/core/hw/sh4/sh4_mem.cpp
+++ b/core/hw/sh4/sh4_mem.cpp
@@ -223,7 +223,7 @@ void mem_Term()
 	sh4_area0_Term();
 
 	//write back Flash/SRAM
-	SaveRomFiles(get_data_path("/data/"));
+	SaveRomFiles(get_writable_data_path("/data/"));
 	
 	//mem_b.Term(); // handled by vmem
 

--- a/core/hw/sh4/sh4_mem.cpp
+++ b/core/hw/sh4/sh4_mem.cpp
@@ -223,7 +223,7 @@ void mem_Term()
 	sh4_area0_Term();
 
 	//write back Flash/SRAM
-	SaveRomFiles(GetPath("/data/"));
+	SaveRomFiles(get_data_path("/data/"));
 	
 	//mem_b.Term(); // handled by vmem
 

--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -266,7 +266,7 @@
 						size_t size_needed = snprintf(NULL, 0, EVDEV_MAPPING_PATH, mapping_fname) + 1;
 						char* mapping_path = (char*)malloc(size_needed);
 						sprintf(mapping_path, EVDEV_MAPPING_PATH, mapping_fname);
-						mapping_fd = fopen(GetPath(mapping_path).c_str(), "r");
+						mapping_fd = fopen(get_readonly_data_path(mapping_path).c_str(), "r");
 						free(mapping_path);
 					}
 					

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -343,6 +343,7 @@ std::vector<string> find_system_config_dirs()
 	}
 	else
 	{
+		dirs.push_back("/etc/reicast"); // This isn't part of the XDG spec, but much more common than /etc/xdg/
 		dirs.push_back("/etc/xdg/reicast");
 	}
 	return dirs;

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -239,7 +239,7 @@ void dc_run();
 	}
 #endif
 
-string get_config_dir()
+string find_user_config_dir()
 {
 	#ifdef USES_HOMEDIR
 		struct stat info;
@@ -259,14 +259,13 @@ string get_config_dir()
 			 *   http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
 			 */
 			home = (string)getenv("HOME") + "/.config/reicast";
-			
 		}
 		if(getenv("XDG_CONFIG_HOME") != NULL)
 		{
 			// If XDG_CONFIG_HOME is set explicitly, we'll use that instead of $HOME/.config
 			home = (string)getenv("XDG_CONFIG_HOME") + "/reicast";
 		}
-		
+
 		if(!home.empty())
 		{
 			if((stat(home.c_str(), &info) != 0) || !(info.st_mode & S_IFDIR))
@@ -277,10 +276,104 @@ string get_config_dir()
 			return home;
 		}
 	#endif
-		
+
 	// Unable to detect config dir, use the current folder
 	return ".";
 }
+
+string find_user_data_dir()
+{
+	#ifdef USES_HOMEDIR
+		struct stat info;
+		string data = "";
+		if(getenv("HOME") != NULL)
+		{
+			// Support for the legacy config dir at "$HOME/.reicast"
+			string legacy_data = (string)getenv("HOME") + "/.reicast";
+			if((stat(legacy_data.c_str(), &info) == 0) && (info.st_mode & S_IFDIR))
+			{
+				// "$HOME/.reicast" already exists, let's use it!
+				return legacy_data;
+			}
+
+			/* If $XDG_DATA_HOME is not set, we're supposed to use "$HOME/.local/share" instead.
+			 * Consult the XDG Base Directory Specification for details:
+			 *   http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+			 */
+			data = (string)getenv("HOME") + "/.local/share/reicast";
+		}
+		if(getenv("XDG_DATA_HOME") != NULL)
+		{
+			// If XDG_DATA_HOME is set explicitly, we'll use that instead of $HOME/.config
+			data = (string)getenv("XDG_DATA_HOME") + "/reicast";
+		}
+		
+		if(!data.empty())
+		{
+			if((stat(data.c_str(), &info) != 0) || !(info.st_mode & S_IFDIR))
+			{
+				// If the directory doesn't exist yet, create it!
+				mkdir(data.c_str(), 0755);
+			}
+			return data;
+		}
+	#endif
+
+	// Unable to detect config dir, use the current folder
+	return ".";
+}
+
+std::vector<string> find_system_config_dirs()
+{
+	std::vector<string> dirs;
+	if (getenv("XDG_DATA_DIRS") != NULL)
+	{
+		string s = (string)getenv("XDG_CONFIG_DIRS");
+
+		string::size_type pos = 0;
+		string::size_type n = s.find(":", pos);
+		while(n != std::string::npos)
+		{
+			dirs.push_back(s.substr(pos, n-pos) + "/reicast");
+			pos = n + 1;
+			n = s.find(":", pos);
+		}
+		// Separator not found
+		dirs.push_back(s.substr(pos) + "/reicast");
+	}
+	else
+	{
+		dirs.push_back("/etc/xdg/reicast");
+	}
+	return dirs;
+}
+
+std::vector<string> find_system_data_dirs()
+{
+	std::vector<string> dirs;
+	if (getenv("XDG_DATA_DIRS") != NULL)
+	{
+		string s = (string)getenv("XDG_DATA_DIRS");
+
+		string::size_type pos = 0;
+		string::size_type n = s.find(":", pos);
+		while(n != std::string::npos)
+		{
+			dirs.push_back(s.substr(pos, n-pos) + "/reicast");
+			pos = n + 1;
+			n = s.find(":", pos);
+		}
+		// Separator not found
+		dirs.push_back(s.substr(pos) + "/reicast");
+	}
+	else
+	{
+		dirs.push_back("/usr/local/share/reicast");
+		dirs.push_back("/usr/share/reicast");
+	}
+	return dirs;
+}
+
 
 int main(int argc, wchar* argv[])
 {
@@ -289,9 +382,22 @@ int main(int argc, wchar* argv[])
 		signal(SIGKILL, clean_exit);
 	#endif
 
-	/* Set home dir */
-	SetHomeDir(get_config_dir());
-	printf("Home dir is: %s\n", GetPath("/").c_str());
+	/* Set directories */
+	set_user_config_dir(find_user_config_dir());
+	set_user_data_dir(find_user_data_dir());
+	std::vector<string> dirs;
+	dirs = find_system_config_dirs();
+	for(unsigned int i = 0; i < dirs.size(); i++)
+	{
+		add_system_data_dir(dirs[i]);
+	}
+	dirs = find_system_data_dirs();
+	for(unsigned int i = 0; i < dirs.size(); i++)
+	{
+		add_system_data_dir(dirs[i]);
+	}
+	printf("Config dir is: %s\n", get_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_data_path("/").c_str());
 
 	common_linux_setup();
 

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -397,8 +397,8 @@ int main(int argc, wchar* argv[])
 	{
 		add_system_data_dir(dirs[i]);
 	}
-	printf("Config dir is: %s\n", get_config_path("/").c_str());
-	printf("Data dir is:   %s\n", get_data_path("/").c_str());
+	printf("Config dir is: %s\n", get_writable_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_writable_data_path("/").c_str());
 
 	common_linux_setup();
 

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -207,7 +207,7 @@ void* prof(void *ptr)
 
 	sprintf(line, "/%d.reprof", tick_count);
 
-		string logfile=get_data_path(line);
+		string logfile=get_writable_data_path(line);
 
 
 		printf("Profiler thread logging to -> %s\n", logfile.c_str());

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -207,7 +207,7 @@ void* prof(void *ptr)
 
 	sprintf(line, "/%d.reprof", tick_count);
 
-		string logfile=GetPath(line);
+		string logfile=get_data_path(line);
 
 
 		printf("Profiler thread logging to -> %s\n", logfile.c_str());

--- a/core/nacl/nacl.cpp
+++ b/core/nacl/nacl.cpp
@@ -48,7 +48,8 @@ void* emuthread(void* ) {
   char *Args[3];
   Args[0] = "dc";
   
-  SetHomeDir("/http");
+	set_user_config_dir("/http");
+	set_user_data_dir("/http");
 
   dc_init(1,Args);
   dc_run();

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -165,9 +165,9 @@ int dc_init(int argc,wchar* argv[])
     #define DATA_PATH "/"
 #endif
     
-	if (settings.bios.UseReios || !LoadRomFiles(GetPath(DATA_PATH)))
+	if (settings.bios.UseReios || !LoadRomFiles(get_data_path(DATA_PATH, false)))
 	{
-		if (!LoadHle(GetPath(DATA_PATH)))
+		if (!LoadHle(get_data_path(DATA_PATH, false)))
 			return -3;
 		else
 			printf("Did not load bios, using reios\n");
@@ -224,7 +224,7 @@ void dc_term()
 #ifndef _ANDROID
 	SaveSettings();
 #endif
-	SaveRomFiles(GetPath("/data/"));
+	SaveRomFiles(get_data_path("/data/"));
 }
 
 void LoadSettings()

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -165,9 +165,9 @@ int dc_init(int argc,wchar* argv[])
     #define DATA_PATH "/"
 #endif
     
-	if (settings.bios.UseReios || !LoadRomFiles(get_data_path(DATA_PATH, false)))
+	if (settings.bios.UseReios || !LoadRomFiles(get_readonly_data_path(DATA_PATH)))
 	{
-		if (!LoadHle(get_data_path(DATA_PATH, false)))
+		if (!LoadHle(get_readonly_data_path(DATA_PATH)))
 			return -3;
 		else
 			printf("Did not load bios, using reios\n");
@@ -224,7 +224,7 @@ void dc_term()
 #ifndef _ANDROID
 	SaveSettings();
 #endif
-	SaveRomFiles(get_data_path("/data/"));
+	SaveRomFiles(get_writable_data_path("/data/"));
 }
 
 void LoadSettings()

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -930,9 +930,9 @@ bool gl_create_resources()
 	#endif
 
 	int w, h;
-	osd_tex=loadPNG(GetPath("/data/buttons.png"),w,h);
+	osd_tex=loadPNG(get_data_path("/data/buttons.png", false),w,h);
 #ifdef TARGET_PANDORA
-	osd_font=loadPNG(GetPath("/font2.png"),w,h);
+	osd_font=loadPNG(get_data_path("/font2.png", false),w,h);
 #endif
 
 	return true;

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -930,9 +930,9 @@ bool gl_create_resources()
 	#endif
 
 	int w, h;
-	osd_tex=loadPNG(get_data_path("/data/buttons.png", false),w,h);
+	osd_tex=loadPNG(get_readonly_data_path("/data/buttons.png"),w,h);
 #ifdef TARGET_PANDORA
-	osd_font=loadPNG(get_data_path("/font2.png", false),w,h);
+	osd_font=loadPNG(get_readonly_data_path("/font2.png"),w,h);
 #endif
 
 	return true;

--- a/core/sdl/main.cpp
+++ b/core/sdl/main.cpp
@@ -446,8 +446,8 @@ int main(int argc, wchar* argv[])
 	set_user_data_dir(".");
 #endif
 
-	printf("Config dir is: %s\n", get_config_path("/").c_str());
-	printf("Data dir is:   %s\n", get_data_path("/").c_str());
+	printf("Config dir is: %s\n", get_writable_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_writable_data_path("/").c_str());
 
 	common_linux_setup();
 

--- a/core/sdl/main.cpp
+++ b/core/sdl/main.cpp
@@ -435,15 +435,19 @@ int main(int argc, wchar* argv[])
 	{
 		home += "/.reicast";
 		mkdir(home.c_str(), 0755); // create the directory if missing
-		SetHomeDir(home);
+		set_user_config_dir(home);
+		set_user_data_dir(home);
 	}
 	else
-		SetHomeDir(".");
+		set_user_config_dir(".");
+		set_user_data_dir(".");
 #else
-	SetHomeDir(".");
+	set_user_config_dir(".");
+	set_user_data_dir(".");
 #endif
 
-	printf("Home dir is: %s\n",GetPath("/").c_str());
+	printf("Config dir is: %s\n", get_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_data_path("/").c_str());
 
 	common_linux_setup();
 

--- a/core/stdclass.cpp
+++ b/core/stdclass.cpp
@@ -43,14 +43,20 @@ void add_system_data_dir(const string& dir)
 	system_data_dirs.push_back(dir);
 }
 
-string get_config_path(const string& filename, bool user_writable)
+string get_writable_config_path(const string& filename)
 {
-	if(user_writable)
+	/* Only stuff in the user_config_dir is supposed to be writable,
+	 * so we always return that.
+	 */
+	return (user_config_dir + filename);
+}
+
+string get_readonly_config_path(const string& filename)
+{
+	string user_filepath = get_writable_config_path(filename);
+	if(file_exists(user_filepath))
 	{
-		/* Only stuff in the user_config_dir is supposed to be writable,
-		 * so we always return that.
-		 */
-		return (user_config_dir + filename);
+		return user_filepath;
 	}
 
 	string filepath;
@@ -63,17 +69,23 @@ string get_config_path(const string& filename, bool user_writable)
 	}
 
 	// Not found, so we return the user variant
-	return (user_config_dir + filename);
+	return user_filepath;
 }
 
-string get_data_path(const string& filename, bool user_writable)
+string get_writable_data_path(const string& filename)
 {
-	if(user_writable)
+	/* Only stuff in the user_data_dir is supposed to be writable,
+	 * so we always return that.
+	 */
+	return (user_data_dir + filename);
+}
+
+string get_readonly_data_path(const string& filename)
+{
+	string user_filepath = get_writable_data_path(filename);
+	if(file_exists(user_filepath))
 	{
-		/* Only stuff in the user_data_dir is supposed to be writable,
-		 * so we always return that.
-		 */
-		return (user_data_dir + filename);
+		return user_filepath;
 	}
 
 	string filepath;
@@ -86,7 +98,7 @@ string get_data_path(const string& filename, bool user_writable)
 	}
 
 	// Not found, so we return the user variant
-	return (user_data_dir + filename);
+	return user_filepath;
 }
 
 

--- a/core/stdclass.cpp
+++ b/core/stdclass.cpp
@@ -1,12 +1,17 @@
-
 #include <string.h>
 #include <vector>
 #include <sys/stat.h>
-
 #include "types.h"
+
+#if BUILD_COMPILER==COMPILER_VC
+	#include <io.h>
+	#define access _access
+	#define R_OK   4
+#else
+	#include <unistd.h>
+#endif
 
 #include "hw/mem/_vmem.h"
-#include "types.h"
 
 string user_config_dir;
 string user_data_dir;
@@ -15,8 +20,7 @@ std::vector<string> system_data_dirs;
 
 bool file_exists(const string& filename)
 {
-	struct stat info;
-	return (stat (filename.c_str(), &info) == 0);
+	return (access(filename.c_str(), R_OK) == 0);
 }
 
 void set_user_config_dir(const string& dir)

--- a/core/stdclass.cpp
+++ b/core/stdclass.cpp
@@ -1,22 +1,88 @@
 
 #include <string.h>
+#include <vector>
+#include <sys/stat.h>
 
 #include "types.h"
 
 #include "hw/mem/_vmem.h"
 #include "types.h"
 
-string home_dir;
+string user_config_dir;
+string user_data_dir;
+std::vector<string> system_config_dirs;
+std::vector<string> system_data_dirs;
 
-void SetHomeDir(const string& home)
+bool file_exists(const string& filename)
 {
-	home_dir=home;
+	struct stat info;
+	return (stat (filename.c_str(), &info) == 0);
 }
 
-//subpath format: /data/fsca-table.bit
-string GetPath(const string& subpath)
+void set_user_config_dir(const string& dir)
 {
-	return (home_dir+subpath);
+	user_config_dir = dir;
+}
+
+void set_user_data_dir(const string& dir)
+{
+	user_data_dir = dir;
+}
+
+void add_system_config_dir(const string& dir)
+{
+	system_config_dirs.push_back(dir);
+}
+
+void add_system_data_dir(const string& dir)
+{
+	system_data_dirs.push_back(dir);
+}
+
+string get_config_path(const string& filename, bool user_writable)
+{
+	if(user_writable)
+	{
+		/* Only stuff in the user_config_dir is supposed to be writable,
+		 * so we always return that.
+		 */
+		return (user_config_dir + filename);
+	}
+
+	string filepath;
+	for (unsigned int i = 0; i < system_config_dirs.size(); i++) {
+		filepath = system_config_dirs[i] + filename;
+		if (file_exists(filepath))
+		{
+			return filepath;
+		}
+	}
+
+	// Not found, so we return the user variant
+	return (user_config_dir + filename);
+}
+
+string get_data_path(const string& filename, bool user_writable)
+{
+	if(user_writable)
+	{
+		/* Only stuff in the user_data_dir is supposed to be writable,
+		 * so we always return that.
+		 */
+		return (user_data_dir + filename);
+	}
+
+	string filepath;
+	for (unsigned int i = 0; i < system_data_dirs.size(); i++) {
+		filepath = system_data_dirs[i] + filename;
+		if (file_exists(filepath))
+		{
+			return filepath;
+		}
+	}
+
+	// Not found, so we return the user variant
+	return (user_data_dir + filename);
 }
 
 

--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -257,8 +257,10 @@ void add_system_config_dir(const string& dir);
 void add_system_data_dir(const string& dir);
 
 //subpath format: /data/fsca-table.bit
-string get_config_path(const string& filename, bool user_writable = true);
-string get_data_path(const string& filename, bool user_writable = true);
+string get_writable_config_path(const string& filename);
+string get_writable_data_path(const string& filename);
+string get_readonly_config_path(const string& filename);
+string get_readonly_data_path(const string& filename);
 
 
 class VArray2

--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -251,9 +251,14 @@ public :
 };
 
 //Set the path !
-void SetHomeDir(const string& home);
+void set_user_config_dir(const string& dir);
+void set_user_data_dir(const string& dir);
+void add_system_config_dir(const string& dir);
+void add_system_data_dir(const string& dir);
+
 //subpath format: /data/fsca-table.bit
-string GetPath(const string& subpath);
+string get_config_path(const string& filename, bool user_writable = true);
+string get_data_path(const string& filename, bool user_writable = true);
 
 
 class VArray2

--- a/core/webui/server.cpp
+++ b/core/webui/server.cpp
@@ -79,7 +79,7 @@ enum demo_protocols {
 	DEMO_PROTOCOL_COUNT
 };
 
-#define WEBUI_PATH get_data_path("/webui")
+#define WEBUI_PATH get_writable_data_path("/webui")
 
 /*
  * We take a strict whitelist approach to stop ../ attacks

--- a/core/webui/server.cpp
+++ b/core/webui/server.cpp
@@ -79,7 +79,7 @@ enum demo_protocols {
 	DEMO_PROTOCOL_COUNT
 };
 
-#define WEBUI_PATH GetPath("/webui")
+#define WEBUI_PATH get_data_path("/webui")
 
 /*
  * We take a strict whitelist approach to stop ../ attacks

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -157,7 +157,8 @@ void SetupPath()
 	GetModuleFileName(0,fname,512);
 	string fn=string(fname);
 	fn=fn.substr(0,fn.find_last_of('\\'));
-	SetHomeDir(fn);
+	set_user_config_dir(fn);
+	set_user_data_dir(fn);
 }
 
 int msgboxf(const wchar* text,unsigned int type,...)

--- a/shell/android/jni/src/Android.cpp
+++ b/shell/android/jni/src/Android.cpp
@@ -255,8 +255,8 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_config(JNIEnv *env,jo
   const char* D = dirName? env->GetStringUTFChars(dirName,0):0;
 	set_user_config_dir(D);
 	set_user_data_dir(D);
-	printf("Config dir is: %s\n", get_config_path("/").c_str());
-	printf("Data dir is:   %s\n", get_data_path("/").c_str());
+	printf("Config dir is: %s\n", get_writable_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_writable_data_path("/").c_str());
   env->ReleaseStringUTFChars(dirName,D);
 }
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_init(JNIEnv *env,jobject obj,jstring fileName)

--- a/shell/android/jni/src/Android.cpp
+++ b/shell/android/jni/src/Android.cpp
@@ -253,8 +253,10 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_config(JNIEnv *env,jo
 {
   // Set home directory based on User config
   const char* D = dirName? env->GetStringUTFChars(dirName,0):0;
-  SetHomeDir(D);
-  printf("Home dir is: '%s'\n",GetPath("/").c_str());
+	set_user_config_dir(D);
+	set_user_data_dir(D);
+	printf("Config dir is: %s\n", get_config_path("/").c_str());
+	printf("Data dir is:   %s\n", get_data_path("/").c_str());
   env->ReleaseStringUTFChars(dirName,D);
 }
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_init(JNIEnv *env,jobject obj,jstring fileName)

--- a/shell/apple/emulator-ios/emulator/ios_main.mm
+++ b/shell/apple/emulator-ios/emulator/ios_main.mm
@@ -71,8 +71,8 @@ extern "C" int reicast_main(int argc, wchar* argv[])
     
     freopen( (homedir + "/log.txt").c_str(), "wb", stdout);
     
-    printf("Config dir is: %s\n", get_config_path("/").c_str());
-    printf("Data dir is:   %s\n", get_data_path("/").c_str());
+    printf("Config dir is: %s\n", get_writable_config_path("/").c_str());
+    printf("Data dir is:   %s\n", get_writable_data_path("/").c_str());
     
     common_linux_setup();
     

--- a/shell/apple/emulator-ios/emulator/ios_main.mm
+++ b/shell/apple/emulator-ios/emulator/ios_main.mm
@@ -66,11 +66,13 @@ extern "C" int reicast_main(int argc, wchar* argv[])
     //ndcid=atoi(argv[1]);
     
     string homedir = [ [[[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] objectAtIndex:0] path] UTF8String];
-    SetHomeDir(homedir);
+    set_user_config_dir(homedir);
+    set_user_data_dir(homedir);
     
     freopen( (homedir + "/log.txt").c_str(), "wb", stdout);
     
-    printf("Home dir is: %s\n",GetPath("/").c_str());
+    printf("Config dir is: %s\n", get_config_path("/").c_str());
+    printf("Data dir is:   %s\n", get_data_path("/").c_str());
     
     common_linux_setup();
     

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -95,10 +95,14 @@ void* emuthread(void*) {
     {
         home += "/.reicast";
         mkdir(home.c_str(), 0755); // create the directory if missing
-        SetHomeDir(home);
+        set_user_config_dir(home);
+        set_user_data_dir(home);
     }
     else
-        SetHomeDir(".");
+    {
+        set_user_config_dir(".");
+        set_user_data_dir(".");
+    }
     char* argv[] = { "reicast" };
     
     dc_init(1,argv);


### PR DESCRIPTION
This one has grown a bit bigger than I expected. Anyhow, I here's a description what this PR does:

It replaces the `GetPath` function with two dedicated functions:

```C++
get_config_path(filename);
get_data_path(filename);
```

The first one gets a path for a config file (we currently only have `emu.cfg`). The second one gets a path for a data file (e.g. `buttons.png`, the VMU saves or the BIOS/Flashrom).

I did this separation, because on some platforms, the stuff is actually saved in different places - on Linux, this is `$HOME/.config/reicast` for config stuff and `$HOME/.local/share/reicast` for data files (see [XDG Basedir Spec](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)).

I also added support for distinguishing writable and read-only files. Both functions take a second parameter (`bool user_writable`). This one is `true` by default.
- If `user_writable` is `true`, it'll always return a user-writable filepath (i.e. 
`~/.config/reicast/somefile.txt` and `~/.local/share/reicast/somefile.txt`, respectively).
- If that variable is `false` and `~/.config/reicast/somefile.txt` / `~/.local/share/reicast/somefile.txt` does not exist, it also checks system-wide dirs (e.g. `/usr/share/reicast` for data files on Linux).

That way, a user can always override the default/system-wide files, but he doesn't have to duplicate them inside the home dir if he doesn't want to.

On all other platforms (e.g. Windows), i just replaced `SetHomeDir(foo)` with:

```C++
set_user_config_dir(foo);
set_user_data_dir(foo);
```

Also, system-wide directories won't be searched for now - but that could easily be added by using:

```C++
add_system_config_dir(foo);
add_system_data_dir(foo);
```

**Example:**
We merged #769 and a user has just installed reicast (either by self-compilation or by installing via package manager).

Input won't work out of the box, because the user needs to copy the `shell/linux/mappings` folder into `~/.reicast` first (even the pre-defined mappings won't work until this happens).

With this PR, it's possible to put the pre-defined mappings into `/usr/share/reicast/mappings`.

When calling `get_data_path("somemapping.cfg")`, reicast will look in these folders:
- `~/.local/share/reicast/somemapping.cfg`
- `/usr/share/local/reicast/somemapping.cfg`
- `/usr/share/reicast/somemapping.cfg` (in that order)

It'll return the first filepath that exists or - if none of the files exist - the user-dir (i.e. `~/.local/share/reicast/somemapping.cfg`).