### PR TITLE
Nixprof: some enchancements

### DIFF
--- a/core/deps/libelf/elf.cpp
+++ b/core/deps/libelf/elf.cpp
@@ -229,7 +229,7 @@ elf_getSectionLink(void *elfFile, int i)
 {
 	return ISELF32 (elfFile)
 		? elf32_getSectionLink((Elf32_Header*)elfFile, i)
-		: 0;
+		: elf64_getSectionLink((Elf64_Header*)elfFile, i);
 }
 
 uint64_t

--- a/core/deps/libelf/elf.h
+++ b/core/deps/libelf/elf.h
@@ -116,6 +116,15 @@ struct elf_symbol {
   uint16_t st_shndx;              // Section index
 };
 
+struct elf64_symbol {
+  uint32_t      st_name;
+  unsigned char st_info;
+  unsigned char st_other;
+  uint16_t      st_shndx;
+  uint64_t      st_value;
+  uint64_t      st_size;
+};
+
 /*
  * constants for Elf32_Phdr.p_flags 
  */

--- a/core/deps/libelf/elf.h
+++ b/core/deps/libelf/elf.h
@@ -176,6 +176,9 @@ struct elf64_symbol {
 #define ELF_PRINT_SECTIONS 2
 #define ELF_PRINT_ALL (ELF_PRINT_PROGRAM_HEADERS | ELF_PRINT_SECTIONS)
 
+/* Symbol types */
+#define STT_FUNC 2 /* Function, code */
+
 /**
  * Checks that elfFile points to a valid elf file. 
  *

--- a/core/deps/libelf/elf64.h
+++ b/core/deps/libelf/elf64.h
@@ -165,6 +165,12 @@ elf64_getSectionType(struct Elf64_Header *file, uint16_t s)
 	return elf64_getSectionTable(file)[s].sh_type;
 }
 
+static inline
+uint32_t elf64_getSectionLink(struct Elf64_Header *file, int s)
+{
+	return elf64_getSectionTable(file)[s].sh_link;
+}
+
 static inline uint32_t 
 elf64_getSectionFlags(struct Elf64_Header *file, uint16_t s)
 {

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -5,6 +5,10 @@
 
 #include "deps/zlib/zlib.h"
 
+#if FEAT_HAS_NIXPROF
+#include "profiler/profiler.h"
+#endif
+
 /*
 
 	rendv3 ideas
@@ -221,6 +225,10 @@ bool rend_single_frame()
 
 void* rend_thread(void* p)
 {
+#if FEAT_HAS_NIXPROF
+	install_prof_handler(1);
+#endif
+
 	#if SET_AFNT
 	cpu_set_t mask;
 

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -41,6 +41,9 @@
 	#include <sys/soundcard.h>
 #endif
 
+#if FEAT_HAS_NIXPROF
+#include "profiler/profiler.h"
+#endif
 
 int msgboxf(const wchar* text, unsigned int type, ...)
 {
@@ -267,6 +270,9 @@ int main(int argc, wchar* argv[])
 	SetupInput();
 
 	#if !defined(TARGET_EMSCRIPTEN)
+		#if FEAT_HAS_NIXPROF
+		install_prof_handler(0);
+		#endif
 		dc_run();
 	#else
 		emscripten_set_main_loop(&dc_run, 100, false);

--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -14,6 +14,10 @@
 #include "linux-dist/x11.h"
 #include "linux-dist/main.h"
 
+#if FEAT_HAS_NIXPROF
+#include "profiler/profiler.h"
+#endif
+
 #if defined(TARGET_PANDORA)
 	#define DEFAULT_FULLSCREEN    1
 	#define DEFAULT_WINDOW_WIDTH  800
@@ -72,6 +76,16 @@ void input_x11_handle()
 					{
 						die("death by escape key");
 					}
+#if FEAT_HAS_NIXPROF
+					else if (e.type == KeyRelease && e.xkey.keycode == 76) // F10 button
+					{
+						if (sample_Switch(3000)) {
+							printf("Starting profiling\n");
+						} else {
+							printf("Stopping profiling\n");
+						}
+					}
+#endif
 					else if (e.type == KeyRelease && e.xkey.keycode == 95) // F11 button
 					{
 						x11_fullscreen = !x11_fullscreen;

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -327,7 +327,7 @@ void sample_Start(int freq)
 	if (prof_run)
 		return;
 	prof_wait = 1000000 / freq;
-	printf("sampling profiler: starting %d hz %d wait\n", freq, prof_wait);
+	printf("sampling profiler: starting %d Hz %d wait\n", freq, prof_wait);
 	prof_run = true;
 	pthread_create(&proft, NULL, profiler_main, 0);
 }

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -190,8 +190,9 @@ static void elf_syms(FILE* out,const char* libfile)
 				uint64_t st_value =  elf32 ? sym[i].st_value : sym64[i].st_value;
 				uint32_t st_name  =  elf32 ? sym[i].st_name  : sym64[i].st_name;
 				uint16_t st_shndx =  elf32 ? sym[i].st_shndx : sym64[i].st_shndx;
+				uint16_t st_type  = (elf32 ? sym[i].st_info  : sym64[i].st_info) & 0xf;
 				uint64_t st_size  =  elf32 ? sym[i].st_size  : sym64[i].st_size;
-				if (st_value && st_name && st_shndx)
+				if (st_type == STT_FUNC && st_value && st_name && st_shndx)
 				{
 					char* name=(char*)elf_getSection(data,dynstr);// sym[i].st_shndx
 					// printf("Symbol %d: %s, %08" PRIx64 ", % " PRIi64 " bytes\n",

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -46,14 +46,14 @@
 #include <stdio.h> 
 #include <string.h> 
 
-int tick_count=0;
-pthread_t proft;
-pthread_t thread[2];
-void*     prof_address[2];
-u32 prof_wait;
+static int tick_count=0;
+static pthread_t proft;
+static pthread_t thread[2];
+static void*     prof_address[2];
+static u32 prof_wait;
 
-u8* syms_ptr;
-int syms_len;
+static u8* syms_ptr;
+static int syms_len;
 
 void sample_Syms(u8* data,u32 len)
 {
@@ -88,16 +88,17 @@ void install_prof_handler(int id)
 	thread[id]=pthread_self();
 }
 
-void prof_head(FILE* out, const char* type, const char* name)
+static void prof_head(FILE* out, const char* type, const char* name)
 {
 	fprintf(out,"==xx==xx==\n%s:%s\n",type,name);
 }
-void prof_head(FILE* out, const char* type, int d)
+
+static void prof_head(FILE* out, const char* type, int d)
 {
 	fprintf(out,"==xx==xx==\n%s:%d\n",type,d);
 }
 
-void elf_syms(FILE* out,const char* libfile)
+static void elf_syms(FILE* out,const char* libfile)
 {
 	struct stat statbuf;
 
@@ -182,9 +183,10 @@ void elf_syms(FILE* out,const char* libfile)
 
 
 
-volatile bool prof_run;
+static volatile bool prof_run;
 
-int str_ends_with(const char * str, const char * suffix)
+// This is not used:
+static int str_ends_with(const char * str, const char * suffix)
 {
 	if (str == NULL || suffix == NULL)
 		return 0;
@@ -200,7 +202,7 @@ int str_ends_with(const char * str, const char * suffix)
 
 void sh4_jitsym(FILE* out);
 
-void* prof(void *ptr)
+static void* prof(void *ptr)
 {
 	FILE* prof_out;
 	char line[512];

--- a/core/profiler/profiler.h
+++ b/core/profiler/profiler.h
@@ -149,4 +149,5 @@ extern profiler_cfg prof;
 void install_prof_handler(int id);
 void sample_Start(int freq);
 void sample_Stop();
+bool sample_Switch(int freq);
 void sample_Syms(u8* data,u32 len);


### PR DESCRIPTION
* Make it available on X11
* Make it work with ELF64
* Use .symtab if available instead of .dynsym
* Only process STT_FUNC symbols
* Use section types and links insteaf of section names to find symbol and string table sections

Some modifications to deps/libelf. Is this code maintained at https://github.com/seL4/libelf? Needs to be upstreamed.

Might be a good idea to use perf or directly perf_event_open (faster, less intrusive, lots of features). For the former, a /tmp/perf-$PID.map can be used to bind SH4 blocks to host addresses.