### PR TITLE
Some groundwork for multiplayer support

### DIFF
--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -3,6 +3,7 @@
 #include "maple_helper.h"
 #include "maple_devs.h"
 #include "maple_cfg.h"
+#include "maple_controller.h"	
 
 #define HAS_VMU
 /*
@@ -21,11 +22,6 @@ Plugins:
 		ImageUpdate(data);
 */
 void UpdateInputState(u32 port);
-
-extern u16 kcode[4];
-extern u32 vks[4];
-extern s8 joyx[4],joyy[4];
-extern u8 rt[4],lt[4];
 
 u8 GetBtFromSgn(s8 val)
 {

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -41,11 +41,11 @@ struct MapleConfigMap : IMapleConfigMap
 	{
 		UpdateInputState(dev->bus_id);
 
-		pjs->kcode=kcode[dev->bus_id] | 0xF901;
-		pjs->joy[PJAI_X1]=GetBtFromSgn(joyx[dev->bus_id]);
-		pjs->joy[PJAI_Y1]=GetBtFromSgn(joyy[dev->bus_id]);
-		pjs->trigger[PJTI_R]=rt[dev->bus_id];
-		pjs->trigger[PJTI_L]=lt[dev->bus_id];
+		pjs->kcode           = maple_controller[dev->bus_id].buttons | 0xF901;
+		pjs->joy[PJAI_X1]    = GetBtFromSgn(maple_controller[dev->bus_id].stick_x);
+		pjs->joy[PJAI_Y1]    = GetBtFromSgn(maple_controller[dev->bus_id].stick_y);
+		pjs->trigger[PJTI_R] = maple_controller[dev->bus_id].trigger_right;
+		pjs->trigger[PJTI_L] = maple_controller[dev->bus_id].trigger_left;
 	}
 	void SetImage(void* img)
 	{
@@ -67,7 +67,7 @@ void mcfg_CreateDevices()
 	#if DC_PLATFORM == DC_PLATFORM_DREAMCAST
 		for(int port = 0; port < MAPLE_NUM_PORTS; port++)
 		{
-			if(port_enabled[port])
+			if(maple_controller[port].enabled)
 			{
 				mcfg_Create(MDT_SegaController, port, 5);
 				mcfg_Create(MDT_SegaVMU,        port, 0);

--- a/core/hw/maple/maple_cfg.cpp
+++ b/core/hw/maple/maple_cfg.cpp
@@ -64,14 +64,19 @@ void mcfg_Create(MapleDeviceType type,u32 bus,u32 port)
 
 void mcfg_CreateDevices()
 {
-#if DC_PLATFORM == DC_PLATFORM_DREAMCAST
-	mcfg_Create(MDT_SegaController,0,5);
-
-	mcfg_Create(MDT_SegaVMU,0,0);
-	mcfg_Create(MDT_SegaVMU,0,1);
-#else
-	mcfg_Create(MDT_NaomiJamma, 0, 5);
-#endif
+	#if DC_PLATFORM == DC_PLATFORM_DREAMCAST
+		for(int port = 0; port < MAPLE_NUM_PORTS; port++)
+		{
+			if(port_enabled[port])
+			{
+				mcfg_Create(MDT_SegaController, port, 5);
+				mcfg_Create(MDT_SegaVMU,        port, 0);
+				mcfg_Create(MDT_SegaVMU,        port, 1);
+			}
+		}
+	#else
+		mcfg_Create(MDT_NaomiJamma, 0, 5);
+	#endif
 }
 
 void mcfg_DestroyDevices()

--- a/core/hw/maple/maple_controller.cpp
+++ b/core/hw/maple/maple_controller.cpp
@@ -1,9 +1,8 @@
 #include "hw/maple/maple_controller.h"
 
-u16 kcode[MAPLE_NUM_PORTS] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
-u8 rt[MAPLE_NUM_PORTS] = {0, 0, 0, 0};
-u8 lt[MAPLE_NUM_PORTS] = {0, 0, 0, 0};
-u32 vks[MAPLE_NUM_PORTS];
-s8 joyx[MAPLE_NUM_PORTS];
-s8 joyy[MAPLE_NUM_PORTS];
-bool port_enabled[MAPLE_NUM_PORTS] = {1, 0, 0, 0};
+MapleController maple_controller[MAPLE_NUM_PORTS] = {
+	{ 1 , 0xFFFF, 0, 0, 0, 0 },
+	{ 0 , 0xFFFF, 0, 0, 0, 0 },
+	{ 0 , 0xFFFF, 0, 0, 0, 0 },
+	{ 0 , 0xFFFF, 0, 0, 0, 0 }
+};

--- a/core/hw/maple/maple_controller.cpp
+++ b/core/hw/maple/maple_controller.cpp
@@ -1,7 +1,9 @@
 #include "hw/maple/maple_controller.h"
 
-u16 kcode[4] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
-u8 rt[4] = {0, 0, 0, 0};
-u8 lt[4] = {0, 0, 0, 0};
-u32 vks[4];
-s8 joyx[4], joyy[4];
+u16 kcode[MAPLE_NUM_PORTS] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
+u8 rt[MAPLE_NUM_PORTS] = {0, 0, 0, 0};
+u8 lt[MAPLE_NUM_PORTS] = {0, 0, 0, 0};
+u32 vks[MAPLE_NUM_PORTS];
+s8 joyx[MAPLE_NUM_PORTS];
+s8 joyy[MAPLE_NUM_PORTS];
+bool port_enabled[MAPLE_NUM_PORTS] = {1, 0, 0, 0};

--- a/core/hw/maple/maple_controller.cpp
+++ b/core/hw/maple/maple_controller.cpp
@@ -1,0 +1,7 @@
+#include "hw/maple/maple_controller.h"
+
+u16 kcode[4] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
+u8 rt[4] = {0, 0, 0, 0};
+u8 lt[4] = {0, 0, 0, 0};
+u32 vks[4];
+s8 joyx[4], joyy[4];

--- a/core/hw/maple/maple_controller.h
+++ b/core/hw/maple/maple_controller.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "types.h"
+
+extern u16 kcode[4];
+extern u32 vks[4];
+extern u8 rt[4], lt[4];
+extern s8 joyx[4], joyy[4];
+
+enum MapleControllerCode
+{
+	DC_BTN_C           = 1,
+	DC_BTN_B           = 1<<1,
+	DC_BTN_A           = 1<<2,
+	DC_BTN_START       = 1<<3,
+	DC_BTN_DPAD_UP     = 1<<4,
+	DC_BTN_DPAD_DOWN   = 1<<5,
+	DC_BTN_DPAD_LEFT   = 1<<6,
+	DC_BTN_DPAD_RIGHT  = 1<<7,
+	DC_BTN_Z           = 1<<8,
+	DC_BTN_Y           = 1<<9,
+	DC_BTN_X           = 1<<10,
+	DC_BTN_D           = 1<<11,
+	DC_BTN_DPAD2_UP    = 1<<12,
+	DC_BTN_DPAD2_DOWN  = 1<<13,
+	DC_BTN_DPAD2_LEFT  = 1<<14,
+	DC_BTN_DPAD2_RIGHT = 1<<15,
+
+	DC_AXIS_LT = 0X10000,
+	DC_AXIS_RT = 0X10001,
+	DC_AXIS_X  = 0X20000,
+	DC_AXIS_Y  = 0X20001
+};

--- a/core/hw/maple/maple_controller.h
+++ b/core/hw/maple/maple_controller.h
@@ -1,10 +1,16 @@
 #pragma once
 #include "types.h"
 
-extern u16 kcode[4];
-extern u32 vks[4];
-extern u8 rt[4], lt[4];
-extern s8 joyx[4], joyy[4];
+// If you change the value of MAPLE_NUM_PORTS, please note that you need to change the initializers in maple_controller.cpp as well
+#define MAPLE_NUM_PORTS 4
+
+extern u16 kcode[MAPLE_NUM_PORTS];
+extern u32 vks[MAPLE_NUM_PORTS];
+extern u8 rt[MAPLE_NUM_PORTS];
+extern u8 lt[MAPLE_NUM_PORTS];
+extern s8 joyx[MAPLE_NUM_PORTS];
+extern s8 joyy[MAPLE_NUM_PORTS];
+extern bool port_enabled[MAPLE_NUM_PORTS];
 
 enum MapleControllerCode
 {

--- a/core/hw/maple/maple_controller.h
+++ b/core/hw/maple/maple_controller.h
@@ -4,13 +4,17 @@
 // If you change the value of MAPLE_NUM_PORTS, please note that you need to change the initializers in maple_controller.cpp as well
 #define MAPLE_NUM_PORTS 4
 
-extern u16 kcode[MAPLE_NUM_PORTS];
-extern u32 vks[MAPLE_NUM_PORTS];
-extern u8 rt[MAPLE_NUM_PORTS];
-extern u8 lt[MAPLE_NUM_PORTS];
-extern s8 joyx[MAPLE_NUM_PORTS];
-extern s8 joyy[MAPLE_NUM_PORTS];
-extern bool port_enabled[MAPLE_NUM_PORTS];
+struct MapleController
+{
+	bool enabled;
+	u16 buttons;
+	u8 trigger_left;
+	u8 trigger_right;
+	s8 stick_x;
+	s8 stick_y;
+};
+
+extern MapleController maple_controller[MAPLE_NUM_PORTS];
 
 enum MapleControllerCode
 {

--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -332,21 +332,21 @@
 					} else if (ie.code == controller->mapping->Btn_Escape) {
 						die("death by escape key");
 					} else if (ie.code == controller->mapping->Btn_DPad_Left) {
-						SET_FLAG(kcode[port], DC_DPAD_LEFT, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Right) {
-						SET_FLAG(kcode[port], DC_DPAD_RIGHT, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Up) {
-						SET_FLAG(kcode[port], DC_DPAD_UP, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD_UP, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Down) {
-						SET_FLAG(kcode[port], DC_DPAD_DOWN, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Left) {
-						SET_FLAG(kcode[port], DC_DPAD2_LEFT, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Right) {
-						SET_FLAG(kcode[port], DC_DPAD2_RIGHT, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Up) {
-						SET_FLAG(kcode[port], DC_DPAD2_UP, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD2_UP, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Down) {
-						SET_FLAG(kcode[port], DC_DPAD2_DOWN, ie.value);
+						SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Trigger_Left) {
 						lt[port] = (ie.value ? 255 : 0);
 					} else if (ie.code == controller->mapping->Btn_Trigger_Right) {
@@ -359,16 +359,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_DPAD_LEFT,  1);
-								SET_FLAG(kcode[port], DC_DPAD_RIGHT, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_DPAD_LEFT,  0);
-								SET_FLAG(kcode[port], DC_DPAD_RIGHT, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_DPAD_LEFT,  0);
-								SET_FLAG(kcode[port], DC_DPAD_RIGHT, 1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 1);
 								break;
 						}
 					}
@@ -377,16 +377,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_DPAD_UP,   1);
-								SET_FLAG(kcode[port], DC_DPAD_DOWN, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,   1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_DPAD_UP,  0);
-								SET_FLAG(kcode[port], DC_DPAD_DOWN, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_DPAD_UP,  0);
-								SET_FLAG(kcode[port], DC_DPAD_DOWN, 1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 1);
 								break;
 						}
 					}
@@ -395,16 +395,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_DPAD2_LEFT,  1);
-								SET_FLAG(kcode[port], DC_DPAD2_RIGHT, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_DPAD2_LEFT,  0);
-								SET_FLAG(kcode[port], DC_DPAD2_RIGHT, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_DPAD2_LEFT,  0);
-								SET_FLAG(kcode[port], DC_DPAD2_RIGHT, 1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 1);
 								break;
 						}
 					}
@@ -413,16 +413,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_DPAD2_UP,   1);
-								SET_FLAG(kcode[port], DC_DPAD2_DOWN, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,   1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_DPAD2_UP,  0);
-								SET_FLAG(kcode[port], DC_DPAD2_DOWN, 0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_DPAD2_UP,  0);
-								SET_FLAG(kcode[port], DC_DPAD2_DOWN, 1);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,  0);
+								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 1);
 								break;
 						}
 					}

--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -314,43 +314,43 @@
 			{
 				case EV_KEY:
 					if (ie.code == controller->mapping->Btn_A) {
-						SET_FLAG(kcode[port], DC_BTN_A, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_A, ie.value);
 					} else if (ie.code == controller->mapping->Btn_B) {
-						SET_FLAG(kcode[port], DC_BTN_B, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_B, ie.value);
 					} else if (ie.code == controller->mapping->Btn_C) {
-						SET_FLAG(kcode[port], DC_BTN_C, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_C, ie.value);
 					} else if (ie.code == controller->mapping->Btn_D) {
-						SET_FLAG(kcode[port], DC_BTN_D, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_D, ie.value);
 					} else if (ie.code == controller->mapping->Btn_X) {
-						SET_FLAG(kcode[port], DC_BTN_X, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_X, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Y) {
-						SET_FLAG(kcode[port], DC_BTN_Y, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_Y, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Z) {
-						SET_FLAG(kcode[port], DC_BTN_Z, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_Z, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Start) {
-						SET_FLAG(kcode[port], DC_BTN_START, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_START, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Escape) {
 						die("death by escape key");
 					} else if (ie.code == controller->mapping->Btn_DPad_Left) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_LEFT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Right) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_RIGHT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Up) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD_UP, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_UP, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad_Down) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_DOWN, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Left) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_LEFT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Right) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_RIGHT, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Up) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD2_UP, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_UP, ie.value);
 					} else if (ie.code == controller->mapping->Btn_DPad2_Down) {
-						SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, ie.value);
+						SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_DOWN, ie.value);
 					} else if (ie.code == controller->mapping->Btn_Trigger_Left) {
-						lt[port] = (ie.value ? 255 : 0);
+						maple_controller[port].trigger_left = (ie.value ? 255 : 0);
 					} else if (ie.code == controller->mapping->Btn_Trigger_Right) {
-						rt[port] = (ie.value ? 255 : 0);
+						maple_controller[port].trigger_right = (ie.value ? 255 : 0);
 					}
 					break;
 				case EV_ABS:
@@ -359,16 +359,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  1);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_LEFT,  1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_RIGHT, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_LEFT,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_RIGHT, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_LEFT,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_RIGHT, 1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_LEFT,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_RIGHT, 1);
 								break;
 						}
 					}
@@ -377,16 +377,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,   1);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_UP,   1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_DOWN, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_UP,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_DOWN, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD_UP,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD_DOWN, 1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_UP,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD_DOWN, 1);
 								break;
 						}
 					}
@@ -395,16 +395,16 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  1);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_LEFT,  1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_RIGHT, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_LEFT,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_RIGHT, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_LEFT,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_RIGHT, 1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_LEFT,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_RIGHT, 1);
 								break;
 						}
 					}
@@ -413,34 +413,34 @@
 						switch(ie.value)
 						{
 							case -1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,   1);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_UP,   1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_DOWN, 0);
 								break;
 							case 0:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_UP,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_DOWN, 0);
 								break;
 							case 1:
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_UP,  0);
-								SET_FLAG(kcode[port], DC_BTN_DPAD2_DOWN, 1);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_UP,  0);
+								SET_FLAG(maple_controller[port].buttons, DC_BTN_DPAD2_DOWN, 1);
 								break;
 						}
 					}
 					else if (ie.code == controller->mapping->Axis_Analog_X)
 					{
-						joyx[port] = (controller->data_x.convert(ie.value) + 128);
+						maple_controller[port].stick_x = (controller->data_x.convert(ie.value) + 128);
 					}
 					else if (ie.code == controller->mapping->Axis_Analog_Y)
 					{
-						joyy[port] = (controller->data_y.convert(ie.value) + 128);
+						maple_controller[port].stick_y = (controller->data_y.convert(ie.value) + 128);
 					}
 					else if (ie.code == controller->mapping->Axis_Trigger_Left)
 					{
-						lt[port] = controller->data_trigger_left.convert(ie.value);
+						maple_controller[port].trigger_left = controller->data_trigger_left.convert(ie.value);
 					}
 					else if (ie.code == controller->mapping->Axis_Trigger_Right)
 					{
-						rt[port] = controller->data_trigger_right.convert(ie.value);
+						maple_controller[port].trigger_right = controller->data_trigger_right.convert(ie.value);
 					}
 					break;
 			}

--- a/core/linux-dist/joystick.cpp
+++ b/core/linux-dist/joystick.cpp
@@ -9,7 +9,7 @@
 	const u32 joystick_map_axis_usb[JOYSTICK_MAP_SIZE]     = { DC_AXIS_X, DC_AXIS_Y, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 	const u32 joystick_map_btn_xbox360[JOYSTICK_MAP_SIZE]  = { DC_BTN_A, DC_BTN_B, DC_BTN_X, DC_BTN_Y, 0, 0, 0, DC_BTN_START, 0, 0 };
-	const u32 joystick_map_axis_xbox360[JOYSTICK_MAP_SIZE] = { DC_AXIS_X, DC_AXIS_Y, DC_AXIS_LT, 0, 0, DC_AXIS_RT, DC_DPAD_LEFT, DC_DPAD_UP, 0, 0 };
+	const u32 joystick_map_axis_xbox360[JOYSTICK_MAP_SIZE] = { DC_AXIS_X, DC_AXIS_Y, DC_AXIS_LT, 0, 0, DC_AXIS_RT, DC_BTN_DPAD_LEFT, DC_BTN_DPAD_UP, 0, 0 };
 
 	const u32* joystick_map_btn = joystick_map_btn_usb;
 	const u32* joystick_map_axis = joystick_map_axis_usb;

--- a/core/linux-dist/joystick.cpp
+++ b/core/linux-dist/joystick.cpp
@@ -73,18 +73,18 @@
 
 					if (mt == 0)
 					{
-						kcode[port] |= mo;
-						kcode[port] |= mo*2;
+						maple_controller[port].buttons |= mo;
+						maple_controller[port].buttons |= mo*2;
 						if (v<-64)
 						{
-							kcode[port] &= ~mo;
+							maple_controller[port].buttons &= ~mo;
 						}
 						else if (v>64)
 						{
-							kcode[port] &= ~(mo*2);
+							maple_controller[port].buttons &= ~(mo*2);
 						}
 
-					 //printf("Mapped to %d %d %d\n",mo,kcode[port]&mo,kcode[port]&(mo*2));
+					 //printf("Mapped to %d %d %d\n",mo,maple_controller[port].buttons&mo,maple_controller[port].buttons&(mo*2));
 					}
 					else if (mt == 1)
 					{
@@ -95,11 +95,11 @@
 						//printf("AXIS %d,%d Mapped to %d %d %d\n",JE.number,JE.value,mo,v,v+127);
 						if (mo == 0)
 						{
-							lt[port] = (v + 127);
+							maple_controller[port].trigger_left = (v + 127);
 						}
 						else if (mo == 1)
 						{
-							rt[port] = (v + 127);
+							maple_controller[port].trigger_right = (v + 127);
 						}
 					}
 					else if (mt == 2)
@@ -107,11 +107,11 @@
 						//  printf("AXIS %d,%d Mapped to %d %d [%d]",JE.number,JE.value,mo,v);
 						if (mo == 0)
 						{
-							joyx[port] = v;
+							maple_controller[port].stick_x = v;
 						}
 						else if (mo == 1)
 						{
-							joyy[port] = v;
+							maple_controller[port].stick_y = v;
 						}
 					}
 				}
@@ -129,11 +129,11 @@
 						// printf("Mapped to %d\n",mo);
 						if (JE.value)
 						{
-							kcode[port] &= ~mo;
+							maple_controller[port].buttons &= ~mo;
 						}
 						else
 						{
-							kcode[port] |= mo;
+							maple_controller[port].buttons |= mo;
 						}
 					}
 					else if (mt == 1)
@@ -141,11 +141,11 @@
 						// printf("Mapped to %d %d\n",mo,JE.value?255:0);
 						if (mo==0)
 						{
-							lt[port] = JE.value ? 255 : 0;
+							maple_controller[port].trigger_left = JE.value ? 255 : 0;
 						}
 						else if (mo==1)
 						{
-							rt[port] = JE.value ? 255 : 0;
+							maple_controller[port].trigger_right = JE.value ? 255 : 0;
 						}
 					}
 				}

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -80,12 +80,7 @@ void emit_WriteCodeCache();
 
 #if defined(USE_EVDEV)
 	/* evdev input */
-	static EvdevController evdev_controllers[4] = {
-		{ -1, NULL },
-		{ -1, NULL },
-		{ -1, NULL },
-		{ -1, NULL }
-	};
+	static EvdevController evdev_controllers[MAPLE_NUM_PORTS];
 #endif
 
 #if defined(USE_JOYSTICK)
@@ -96,14 +91,17 @@ void emit_WriteCodeCache();
 void SetupInput()
 {
 	#if defined(USE_EVDEV)
-		int evdev_device_id[4] = { -1, -1, -1, -1 };
+		int evdev_device_id[MAPLE_NUM_PORTS];
 		size_t size_needed;
 		int port, i;
 
 		char* evdev_device;
 
-		for (port = 0; port < 4; port++)
+		for (port = 0; port < MAPLE_NUM_PORTS; port++)
 		{
+			evdev_controllers[port] = { -1, NULL };
+			evdev_device_id[port] = -1;
+
 			size_needed = snprintf(NULL, 0, EVDEV_DEVICE_CONFIG_KEY, port+1) + 1;
 			char* evdev_config_key = (char*)malloc(size_needed);
 			sprintf(evdev_config_key, EVDEV_DEVICE_CONFIG_KEY, port+1);

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -76,12 +76,6 @@ void* libPvr_GetRenderSurface()
 	return x11_disp;
 }
 
-u16 kcode[4] = {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF};
-u8 rt[4] = {0, 0, 0, 0};
-u8 lt[4] = {0, 0, 0, 0};
-u32 vks[4];
-s8 joyx[4], joyy[4];
-
 void emit_WriteCodeCache();
 
 #if defined(USE_EVDEV)

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -134,6 +134,7 @@ void SetupInput()
 				free(evdev_config_key);
 
 				input_evdev_init(&evdev_controllers[port], evdev_device, mapping);
+				maple_controller[port].enabled = true;
 
 				free(evdev_device);
 			}

--- a/core/linux-dist/main.h
+++ b/core/linux-dist/main.h
@@ -1,35 +1,6 @@
 #pragma once
 #include "types.h"
-
-extern u16 kcode[4];
-extern u32 vks[4];
-extern u8 rt[4], lt[4];
-extern s8 joyx[4], joyy[4];
+#include "hw/maple/maple_controller.h"
 
 extern void* x11_win;
 extern void* x11_disp;
-
-enum DreamcastController
-{
-	DC_BTN_C       = 1,
-	DC_BTN_B       = 1<<1,
-	DC_BTN_A       = 1<<2,
-	DC_BTN_START   = 1<<3,
-	DC_DPAD_UP     = 1<<4,
-	DC_DPAD_DOWN   = 1<<5,
-	DC_DPAD_LEFT   = 1<<6,
-	DC_DPAD_RIGHT  = 1<<7,
-	DC_BTN_Z       = 1<<8,
-	DC_BTN_Y       = 1<<9,
-	DC_BTN_X       = 1<<10,
-	DC_BTN_D       = 1<<11,
-	DC_DPAD2_UP    = 1<<12,
-	DC_DPAD2_DOWN  = 1<<13,
-	DC_DPAD2_LEFT  = 1<<14,
-	DC_DPAD2_RIGHT = 1<<15,
-
-	DC_AXIS_LT = 0X10000,
-	DC_AXIS_RT = 0X10001,
-	DC_AXIS_X  = 0X20000,
-	DC_AXIS_Y  = 0X20001,
-};

--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -117,11 +117,11 @@ void input_x11_handle()
 
 void input_x11_init()
 {
-	x11_keymap[113] = DC_DPAD_LEFT;
-	x11_keymap[114] = DC_DPAD_RIGHT;
+	x11_keymap[113] = DC_BTN_DPAD_LEFT;
+	x11_keymap[114] = DC_BTN_DPAD_RIGHT;
 
-	x11_keymap[111] = DC_DPAD_UP;
-	x11_keymap[116] = DC_DPAD_DOWN;
+	x11_keymap[111] = DC_BTN_DPAD_UP;
+	x11_keymap[116] = DC_BTN_DPAD_DOWN;
 
 	x11_keymap[53] = DC_BTN_X;
 	x11_keymap[54] = DC_BTN_B;

--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -101,11 +101,11 @@ void input_x11_handle()
 						int dc_key = x11_keymap[e.xkey.keycode];
 						if (e.type == KeyPress)
 						{
-							kcode[0] &= ~dc_key;
+							maple_controller[0].buttons &= ~dc_key;
 						}
 						else
 						{
-							kcode[0] |= dc_key;
+							maple_controller[0].buttons |= dc_key;
 						}
 					}
 					//printf("KEY: %d -> %d: %d\n",e.xkey.keycode, dc_key, x11_dc_buttons );

--- a/core/nacl/nacl.cpp
+++ b/core/nacl/nacl.cpp
@@ -15,6 +15,7 @@
 #include "ppapi/utility/completion_callback_factory.h"
 
 #include "types.h"
+#include "hw/maple/maple_controller.h"
 
 #include <GLES2/gl2.h>
 
@@ -234,12 +235,6 @@ Module* CreateModule() {
   return new hello_world::HelloWorldModule();
 }
 }  // namespace pp
-
-
-u16 kcode[4];
-u32 vks[4];
-s8 joyx[4],joyy[4];
-u8 rt[4],lt[4];
 
 int get_mic_data(u8* buffer) { return 0; }
 int push_vmu_screen(u8* buffer) { return 0; }

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -2,6 +2,7 @@
 #include "gles.h"
 #include "rend/TexCache.h"
 #include "cfg/cfg.h"
+#include "hw/maple/maple_controller.h"
 
 #ifdef TARGET_PANDORA
 #include <unistd.h>
@@ -1043,28 +1044,6 @@ void tryfit(float* x,float* y)
 	//printf("%f\n",B*log(maxdev)/log(2.0)+A);
 }
 
-
-
-extern u16 kcode[4];
-extern u8 rt[4],lt[4];
-
-#define key_CONT_C           (1 << 0)
-#define key_CONT_B           (1 << 1)
-#define key_CONT_A           (1 << 2)
-#define key_CONT_START       (1 << 3)
-#define key_CONT_DPAD_UP     (1 << 4)
-#define key_CONT_DPAD_DOWN   (1 << 5)
-#define key_CONT_DPAD_LEFT   (1 << 6)
-#define key_CONT_DPAD_RIGHT  (1 << 7)
-#define key_CONT_Z           (1 << 8)
-#define key_CONT_Y           (1 << 9)
-#define key_CONT_X           (1 << 10)
-#define key_CONT_D           (1 << 11)
-#define key_CONT_DPAD2_UP    (1 << 12)
-#define key_CONT_DPAD2_DOWN  (1 << 13)
-#define key_CONT_DPAD2_LEFT  (1 << 14)
-#define key_CONT_DPAD2_RIGHT (1 << 15)
-
 u32 osd_base;
 u32 osd_count;
 
@@ -1260,17 +1239,17 @@ static void OSD_HOOK()
 	osd_count=0;
 
 	#ifndef TARGET_PANDORA
-	DrawButton2(vjoy_pos[0],kcode[0]&key_CONT_DPAD_LEFT);
-	DrawButton2(vjoy_pos[1],kcode[0]&key_CONT_DPAD_UP);
-	DrawButton2(vjoy_pos[2],kcode[0]&key_CONT_DPAD_RIGHT);
-	DrawButton2(vjoy_pos[3],kcode[0]&key_CONT_DPAD_DOWN);
+	DrawButton2(vjoy_pos[0],kcode[0]&DC_BTN_DPAD_LEFT);
+	DrawButton2(vjoy_pos[1],kcode[0]&DC_BTN_DPAD_UP);
+	DrawButton2(vjoy_pos[2],kcode[0]&DC_BTN_DPAD_RIGHT);
+	DrawButton2(vjoy_pos[3],kcode[0]&DC_BTN_DPAD_DOWN);
 
-	DrawButton2(vjoy_pos[4],kcode[0]&key_CONT_X);
-	DrawButton2(vjoy_pos[5],kcode[0]&key_CONT_Y);
-	DrawButton2(vjoy_pos[6],kcode[0]&key_CONT_B);
-	DrawButton2(vjoy_pos[7],kcode[0]&key_CONT_A);
+	DrawButton2(vjoy_pos[4],kcode[0]&DC_BTN_X);
+	DrawButton2(vjoy_pos[5],kcode[0]&DC_BTN_Y);
+	DrawButton2(vjoy_pos[6],kcode[0]&DC_BTN_B);
+	DrawButton2(vjoy_pos[7],kcode[0]&DC_BTN_A);
 
-	DrawButton2(vjoy_pos[8],kcode[0]&key_CONT_START);
+	DrawButton2(vjoy_pos[8],kcode[0]&DC_BTN_START);
 
 	DrawButton(vjoy_pos[9],lt[0]);
 
@@ -1817,8 +1796,6 @@ bool RenderFrame()
 #define SET_AFNT 1
 #endif
 #endif
-
-extern u16 kcode[4];
 
 /*
 bool rend_single_frame()

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -1239,21 +1239,21 @@ static void OSD_HOOK()
 	osd_count=0;
 
 	#ifndef TARGET_PANDORA
-	DrawButton2(vjoy_pos[0],kcode[0]&DC_BTN_DPAD_LEFT);
-	DrawButton2(vjoy_pos[1],kcode[0]&DC_BTN_DPAD_UP);
-	DrawButton2(vjoy_pos[2],kcode[0]&DC_BTN_DPAD_RIGHT);
-	DrawButton2(vjoy_pos[3],kcode[0]&DC_BTN_DPAD_DOWN);
+	DrawButton2(vjoy_pos[0], maple_controller[0].buttons & DC_BTN_DPAD_LEFT);
+	DrawButton2(vjoy_pos[1], maple_controller[0].buttons & DC_BTN_DPAD_UP);
+	DrawButton2(vjoy_pos[2], maple_controller[0].buttons & DC_BTN_DPAD_RIGHT);
+	DrawButton2(vjoy_pos[3], maple_controller[0].buttons & DC_BTN_DPAD_DOWN);
 
-	DrawButton2(vjoy_pos[4],kcode[0]&DC_BTN_X);
-	DrawButton2(vjoy_pos[5],kcode[0]&DC_BTN_Y);
-	DrawButton2(vjoy_pos[6],kcode[0]&DC_BTN_B);
-	DrawButton2(vjoy_pos[7],kcode[0]&DC_BTN_A);
+	DrawButton2(vjoy_pos[4], maple_controller[0].buttons & DC_BTN_X);
+	DrawButton2(vjoy_pos[5], maple_controller[0].buttons & DC_BTN_Y);
+	DrawButton2(vjoy_pos[6], maple_controller[0].buttons & DC_BTN_B);
+	DrawButton2(vjoy_pos[7], maple_controller[0].buttons & DC_BTN_A);
 
-	DrawButton2(vjoy_pos[8],kcode[0]&DC_BTN_START);
+	DrawButton2(vjoy_pos[8], maple_controller[0].buttons & DC_BTN_START);
 
-	DrawButton(vjoy_pos[9],lt[0]);
+	DrawButton(vjoy_pos[9],  maple_controller[0].trigger_left);
 
-	DrawButton(vjoy_pos[10],rt[0]);
+	DrawButton(vjoy_pos[10], maple_controller[0].trigger_right);
 
 	DrawButton2(vjoy_pos[11],1);
 	DrawButton2(vjoy_pos[12],0);
@@ -1810,7 +1810,7 @@ bool rend_single_frame()
 	}
 
 	bool do_swp=false;
-	//if (kcode[0]&(1<<9))
+	//if (maple_controller[0].buttons&(1<<9))
 	{
 
 

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -41,7 +41,7 @@ const u32 sdl_map_btn_xbox360[SDL_MAP_SIZE] =
 	{ DC_BTN_A, DC_BTN_B, DC_BTN_X, DC_BTN_Y, 0, 0, 0, DC_BTN_START, 0, 0 };
 
 const u32 sdl_map_axis_xbox360[SDL_MAP_SIZE] =
-	{ DC_AXIS_X, DC_AXIS_Y, DC_AXIS_LT, 0, 0, DC_AXIS_RT, DC_DPAD_LEFT, DC_DPAD_UP, 0, 0 };
+	{ DC_AXIS_X, DC_AXIS_Y, DC_AXIS_LT, 0, 0, DC_AXIS_RT, DC_BTN_DPAD_LEFT, DC_BTN_DPAD_UP, 0, 0 };
 
 const u32* sdl_map_btn  = sdl_map_btn_usb;
 const u32* sdl_map_axis = sdl_map_axis_usb;
@@ -370,10 +370,10 @@ void input_sdl_handle(u32 port)
 	if (keys[7]) { kcode[port] &= ~DC_BTN_B; }
 	if (keys[5]) { kcode[port] &= ~DC_BTN_Y; }
 	if (keys[8]) { kcode[port] &= ~DC_BTN_X; }
-	if (keys[1]) { kcode[port] &= ~DC_DPAD_UP; }
-	if (keys[2]) { kcode[port] &= ~DC_DPAD_DOWN; }
-	if (keys[3]) { kcode[port] &= ~DC_DPAD_LEFT; }
-	if (keys[4]) { kcode[port] &= ~DC_DPAD_RIGHT; }
+	if (keys[1]) { kcode[port] &= ~DC_BTN_DPAD_UP; }
+	if (keys[2]) { kcode[port] &= ~DC_BTN_DPAD_DOWN; }
+	if (keys[3]) { kcode[port] &= ~DC_BTN_DPAD_LEFT; }
+	if (keys[4]) { kcode[port] &= ~DC_BTN_DPAD_RIGHT; }
 	if (keys[12]){ kcode[port] &= ~DC_BTN_START; }
 	if (keys[9])
 	{ 

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -206,20 +206,20 @@ void input_sdl_handle(u32 port)
 					{
 						// printf("Mapped to %d\n",mo);
 						if (value)
-						kcode[port] &= ~mo;
+						maple_controller[port].buttons &= ~mo;
 						else
-						kcode[port] |= mo;
+						maple_controller[port].buttons |= mo;
 					}
 					else if (mt == 1)
 					{
 						// printf("Mapped to %d %d\n",mo,JE.value?255:0);
 						if (mo == 0)
 						{
-							lt[port] = value ? 255 : 0;
+							maple_controller[port].trigger_left = value ? 255 : 0;
 						}
 						else if (mo == 1)
 						{
-							rt[port] = value ? 255 : 0;
+							maple_controller[port].trigger_right = value ? 255 : 0;
 						}
 					}
 					
@@ -240,18 +240,18 @@ void input_sdl_handle(u32 port)
 					
 					if (mt == 0)
 					{
-						kcode[port] |= mo;
-						kcode[port] |= mo*2;
+						maple_controller[port].buttons |= mo;
+						maple_controller[port].buttons |= mo*2;
 						if (v < -64)
 						{
-							kcode[port] &= ~mo;
+							maple_controller[port].buttons &= ~mo;
 						}
 						else if (v > 64)
 						{
-							kcode[port] &= ~(mo*2);
+							maple_controller[port].buttons &= ~(mo*2);
 						}
 						
-						// printf("Mapped to %d %d %d\n",mo,kcode[port]&mo,kcode[port]&(mo*2));
+						// printf("Mapped to %d %d %d\n",mo,maple_controller[port].buttons&mo,maple_controller[port].buttons&(mo*2));
 					}
 					else if (mt == 1)
 					{
@@ -261,11 +261,11 @@ void input_sdl_handle(u32 port)
 						
 						if (mo == 0)
 						{
-							lt[port] = v + 127;
+							maple_controller[port].trigger_left = v + 127;
 						}
 						else if (mo == 1)
 						{
-							rt[port] = v + 127;
+							maple_controller[port].trigger_right = v + 127;
 						}
 					}
 					else if (mt == 2)
@@ -273,11 +273,11 @@ void input_sdl_handle(u32 port)
 						//  printf("AXIS %d,%d Mapped to %d %d [%d]",JE.number,JE.value,mo,v);
 						if (mo == 0)
 						{
-							joyx[port] = v;
+							maple_controller[port].stick_x = v;
 						}
 						else if (mo==1)
 						{
-							joyy[port] = v;
+							maple_controller[port].stick_y = v;
 						}
 					}
 				}
@@ -325,39 +325,39 @@ void input_sdl_handle(u32 port)
 						case 1:  // Up=RT, Down=LT
 							if (yy<0)
 							{
-								rt[port] = -yy;
+								maple_controller[port].trigger_right = -yy;
 							}
 							else if (yy>0)
 							{
-								lt[port] = yy;
+								maple_controller[port].trigger_left = yy;
 							}
 							break;
 						case 2:  // Left=LT, Right=RT
 							if (xx < 0)
 							{
-								lt[port] = -xx;
+								maple_controller[port].trigger_left = -xx;
 							}
 							else if (xx > 0)
 							{
-								rt[port] = xx;
+								maple_controller[port].trigger_right = xx;
 							}
 							break;
 						case 3:  // Nub = ABXY
 							if (xx < -127)
 							{
-								kcode[port] &= ~DC_BTN_X;
+								maple_controller[port].buttons &= ~DC_BTN_X;
 							}
 							else if (xx > 127)
 							{
-								kcode[port] &= ~DC_BTN_B;
+								maple_controller[port].buttons &= ~DC_BTN_B;
 							}
 							if (yy < -127)
 							{
-								kcode[port] &= ~DC_BTN_Y;
+								maple_controller[port].buttons &= ~DC_BTN_Y;
 							}
 							else if (yy > 127)
 							{
-								kcode[port] &= ~DC_BTN_A;
+								maple_controller[port].buttons &= ~DC_BTN_A;
 							}
 							break;
 					}
@@ -365,16 +365,16 @@ void input_sdl_handle(u32 port)
 		}
 	}
 			
-	if (keys[0]) { kcode[port] &= ~DC_BTN_C; }
-	if (keys[6]) { kcode[port] &= ~DC_BTN_A; }
-	if (keys[7]) { kcode[port] &= ~DC_BTN_B; }
-	if (keys[5]) { kcode[port] &= ~DC_BTN_Y; }
-	if (keys[8]) { kcode[port] &= ~DC_BTN_X; }
-	if (keys[1]) { kcode[port] &= ~DC_BTN_DPAD_UP; }
-	if (keys[2]) { kcode[port] &= ~DC_BTN_DPAD_DOWN; }
-	if (keys[3]) { kcode[port] &= ~DC_BTN_DPAD_LEFT; }
-	if (keys[4]) { kcode[port] &= ~DC_BTN_DPAD_RIGHT; }
-	if (keys[12]){ kcode[port] &= ~DC_BTN_START; }
+	if (keys[0]) { maple_controller[port].buttons &= ~DC_BTN_C; }
+	if (keys[6]) { maple_controller[port].buttons &= ~DC_BTN_A; }
+	if (keys[7]) { maple_controller[port].buttons &= ~DC_BTN_B; }
+	if (keys[5]) { maple_controller[port].buttons &= ~DC_BTN_Y; }
+	if (keys[8]) { maple_controller[port].buttons &= ~DC_BTN_X; }
+	if (keys[1]) { maple_controller[port].buttons &= ~DC_BTN_DPAD_UP; }
+	if (keys[2]) { maple_controller[port].buttons &= ~DC_BTN_DPAD_DOWN; }
+	if (keys[3]) { maple_controller[port].buttons &= ~DC_BTN_DPAD_LEFT; }
+	if (keys[4]) { maple_controller[port].buttons &= ~DC_BTN_DPAD_RIGHT; }
+	if (keys[12]){ maple_controller[port].buttons &= ~DC_BTN_START; }
 	if (keys[9])
 	{ 
 		dc_term();
@@ -384,11 +384,11 @@ void input_sdl_handle(u32 port)
 	} 
 	if (keys[10])
 	{
-		rt[port] = 255;
+		maple_controller[port].trigger_right = 255;
 	}
 	if (keys[11])
 	{
-		lt[port] = 255;
+		maple_controller[port].trigger_left = 255;
 	}
 }
 

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -1,5 +1,6 @@
 #include "oslib\oslib.h"
 #include "oslib\audiostream.h"
+#include "hw\maple\maple_controller.h"
 #include "imgread\common.h"
 
 #define _WIN32_WINNT 0x0500 
@@ -174,26 +175,6 @@ int msgboxf(const wchar* text,unsigned int type,...)
 	return MessageBox(NULL,temp,VER_SHORTNAME,type | MB_TASKMODAL);
 }
 
-u16 kcode[4];
-u32 vks[4];
-s8 joyx[4],joyy[4];
-u8 rt[4],lt[4];
-#define key_CONT_C            (1 << 0)
-#define key_CONT_B            (1 << 1)
-#define key_CONT_A            (1 << 2)
-#define key_CONT_START        (1 << 3)
-#define key_CONT_DPAD_UP      (1 << 4)
-#define key_CONT_DPAD_DOWN    (1 << 5)
-#define key_CONT_DPAD_LEFT    (1 << 6)
-#define key_CONT_DPAD_RIGHT   (1 << 7)
-#define key_CONT_Z            (1 << 8)
-#define key_CONT_Y            (1 << 9)
-#define key_CONT_X            (1 << 10)
-#define key_CONT_D            (1 << 11)
-#define key_CONT_DPAD2_UP     (1 << 12)
-#define key_CONT_DPAD2_DOWN   (1 << 13)
-#define key_CONT_DPAD2_LEFT   (1 << 14)
-#define key_CONT_DPAD2_RIGHT  (1 << 15)
 void UpdateInputState(u32 port)
 	{
 		//joyx[port]=pad.Lx;
@@ -215,25 +196,25 @@ void UpdateInputState(u32 port)
 
 		kcode[port]=0xFFFF;
 		if (GetAsyncKeyState('V'))
-			kcode[port]&=~key_CONT_A;
+			kcode[port]&=~DC_BTN_A;
 		if (GetAsyncKeyState('C'))
-			kcode[port]&=~key_CONT_B;
+			kcode[port]&=~DC_BTN_B;
 		if (GetAsyncKeyState('X'))
-			kcode[port]&=~key_CONT_Y;
+			kcode[port]&=~DC_BTN_Y;
 		if (GetAsyncKeyState('Z'))
-			kcode[port]&=~key_CONT_X;
+			kcode[port]&=~DC_BTN_X;
 
 		if (GetAsyncKeyState(VK_SHIFT))
-			kcode[port]&=~key_CONT_START;
+			kcode[port]&=~DC_BTN_START;
 
 		if (GetAsyncKeyState(VK_UP))
-			kcode[port]&=~key_CONT_DPAD_UP;
+			kcode[port]&=~DC_BTN_DPAD_UP;
 		if (GetAsyncKeyState(VK_DOWN))
-			kcode[port]&=~key_CONT_DPAD_DOWN;
+			kcode[port]&=~DC_BTN_DPAD_DOWN;
 		if (GetAsyncKeyState(VK_LEFT))
-			kcode[port]&=~key_CONT_DPAD_LEFT;
+			kcode[port]&=~DC_BTN_DPAD_LEFT;
 		if (GetAsyncKeyState(VK_RIGHT))
-			kcode[port]&=~key_CONT_DPAD_RIGHT;
+			kcode[port]&=~DC_BTN_DPAD_RIGHT;
 
 		if (GetAsyncKeyState(VK_F1))
 			settings.pvr.ta_skip = 100;

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -177,44 +177,44 @@ int msgboxf(const wchar* text,unsigned int type,...)
 
 void UpdateInputState(u32 port)
 	{
-		//joyx[port]=pad.Lx;
-		//joyy[port]=pad.Ly;
-		lt[port]=GetAsyncKeyState('A')?255:0;
-		rt[port]=GetAsyncKeyState('S')?255:0;
+		//maple_controller[port].stick_x = pad.Lx;
+		//maple_controller[port].stick_y = pad.Ly;
+		maple_controller[port].trigger_left  = GetAsyncKeyState('A') ? 255 : 0;
+		maple_controller[port].trigger_right = GetAsyncKeyState('S') ? 255 : 0;
 
-		joyx[port]=joyy[port]=0;
+		maple_controller[port].stick_x = maple_controller[port].stick_y = 0;
 
 		if (GetAsyncKeyState('J'))
-			joyx[port]-=126;
+			maple_controller[port].stick_x -= 126;
 		if (GetAsyncKeyState('L'))
-			joyx[port]+=126;
+			maple_controller[port].stick_x += 126;
 
 		if (GetAsyncKeyState('I'))
-			joyy[port]-=126;
+			maple_controller[port].stick_y -= 126;
 		if (GetAsyncKeyState('K'))
-			joyy[port]+=126;
+			maple_controller[port].stick_y += 126;
 
-		kcode[port]=0xFFFF;
+		maple_controller[port].buttons = 0xFFFF;
 		if (GetAsyncKeyState('V'))
-			kcode[port]&=~DC_BTN_A;
+			maple_controller[port].buttons &= ~DC_BTN_A;
 		if (GetAsyncKeyState('C'))
-			kcode[port]&=~DC_BTN_B;
+			maple_controller[port].buttons &= ~DC_BTN_B;
 		if (GetAsyncKeyState('X'))
-			kcode[port]&=~DC_BTN_Y;
+			maple_controller[port].buttons &= ~DC_BTN_Y;
 		if (GetAsyncKeyState('Z'))
-			kcode[port]&=~DC_BTN_X;
+			maple_controller[port].buttons &= ~DC_BTN_X;
 
 		if (GetAsyncKeyState(VK_SHIFT))
-			kcode[port]&=~DC_BTN_START;
+			maple_controller[port].buttons &= ~DC_BTN_START;
 
 		if (GetAsyncKeyState(VK_UP))
-			kcode[port]&=~DC_BTN_DPAD_UP;
+			maple_controller[port].buttons &= ~DC_BTN_DPAD_UP;
 		if (GetAsyncKeyState(VK_DOWN))
-			kcode[port]&=~DC_BTN_DPAD_DOWN;
+			maple_controller[port].buttons &= ~DC_BTN_DPAD_DOWN;
 		if (GetAsyncKeyState(VK_LEFT))
-			kcode[port]&=~DC_BTN_DPAD_LEFT;
+			maple_controller[port].buttons &= ~DC_BTN_DPAD_LEFT;
 		if (GetAsyncKeyState(VK_RIGHT))
-			kcode[port]&=~DC_BTN_DPAD_RIGHT;
+			maple_controller[port].buttons &= ~DC_BTN_DPAD_RIGHT;
 
 		if (GetAsyncKeyState(VK_F1))
 			settings.pvr.ta_skip = 100;

--- a/shell/android/jni/src/Android.cpp
+++ b/shell/android/jni/src/Android.cpp
@@ -208,7 +208,7 @@ static void *ThreadHandler(void *UserData)
   }
 
   // Add additonal controllers
-  for (int i = 0; i < 3; i++)
+  for (int i = 0; i < (MAPLE_NUM_PORTS - 1); i++)
   {
     if (add_controllers[i])
       mcfg_Create(MDT_SegaController,i+1,5);
@@ -442,7 +442,7 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_kcode(JNIEnv * env, j
 	jint *jx_body = env->GetIntArrayElements(jx, 0);
 	jint *jy_body = env->GetIntArrayElements(jy, 0);
 
-	for(int i = 0; i < 4; i++)
+	for(int i = 0; i < MAPLE_NUM_PORTS; i++)
 	{
 		kcode[i] = k_code_body[i];	
 		lt[i] = l_t_body[i];

--- a/shell/android/jni/src/Android.cpp
+++ b/shell/android/jni/src/Android.cpp
@@ -444,11 +444,11 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_kcode(JNIEnv * env, j
 
 	for(int i = 0; i < MAPLE_NUM_PORTS; i++)
 	{
-		kcode[i] = k_code_body[i];	
-		lt[i] = l_t_body[i];
-		rt[i] = r_t_body[i];
-		joyx[i] = jx_body[i];
-		joyy[i] = jy_body[i];
+		maple_controller[i].buttons       = k_code_body[i];
+		maple_controller[i].trigger_left  = l_t_body[i];
+		maple_controller[i].trigger_right = r_t_body[i];
+		maple_controller[i].stick_x       = jx_body[i];
+		maple_controller[i].stick_y       = jy_body[i];
 	}
 
 	env->ReleaseIntArrayElements(k_code, k_code_body, 0);

--- a/shell/android/jni/src/Android.cpp
+++ b/shell/android/jni/src/Android.cpp
@@ -16,6 +16,7 @@
 #include "rend/TexCache.h"
 #include "hw/maple/maple_devs.h"
 #include "hw/maple/maple_if.h"
+#include "hw/maple/maple_controller.h"
 #include "oslib/audiobackend_android.h"
 
 #include "util.h"
@@ -175,10 +176,6 @@ static char CurFileName[256];
 // Additonal controllers 2, 3 and 4 connected ?
 static bool add_controllers[3] = { false, false, false };
 
-u16 kcode[4];
-u32 vks[4];
-s8 joyx[4],joyy[4];
-u8 rt[4],lt[4];
 float vjoy_pos[14][8];
 
 extern bool print_stats;

--- a/shell/apple/emulator-ios/emulator/EmulatorView.mm
+++ b/shell/apple/emulator-ios/emulator/EmulatorView.mm
@@ -26,9 +26,9 @@ int dpad_or_btn = 0;
 -(void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     
     if (dpad_or_btn &1)
-        kcode[0] &= ~(DC_BTN_START|DC_BTN_A);
+        maple_controller[0].buttons &= ~(DC_BTN_START|DC_BTN_A);
     else
-        kcode[0] &= ~(DC_BTN_DPAD_LEFT);
+        maple_controller[0].buttons &= ~(DC_BTN_DPAD_LEFT);
 }
 
 -(void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -36,9 +36,9 @@ int dpad_or_btn = 0;
     //	[event allTouches];
     
     if (dpad_or_btn &1)
-        kcode[0] |= (DC_BTN_START|DC_BTN_A);
+        maple_controller[0].buttons |= (DC_BTN_START|DC_BTN_A);
     else
-        kcode[0] |= (DC_BTN_DPAD_LEFT);
+        maple_controller[0].buttons |= (DC_BTN_DPAD_LEFT);
     
     dpad_or_btn++;
 }

--- a/shell/apple/emulator-ios/emulator/EmulatorView.mm
+++ b/shell/apple/emulator-ios/emulator/EmulatorView.mm
@@ -9,15 +9,7 @@
 #import "EmulatorView.h"
 
 #include "types.h"
-
-extern u16 kcode[4];
-extern u32 vks[4];
-extern s8 joyx[4],joyy[4];
-extern u8 rt[4],lt[4];
-
-#define key_CONT_A           (1 << 2)
-#define key_CONT_START       (1 << 3)
-#define key_CONT_DPAD_LEFT   (1 << 6)
+#include "hw/maple/maple_controller.h"
 
 int dpad_or_btn = 0;
 
@@ -34,9 +26,9 @@ int dpad_or_btn = 0;
 -(void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
     
     if (dpad_or_btn &1)
-        kcode[0] &= ~(key_CONT_START|key_CONT_A);
+        kcode[0] &= ~(DC_BTN_START|DC_BTN_A);
     else
-        kcode[0] &= ~(key_CONT_DPAD_LEFT);
+        kcode[0] &= ~(DC_BTN_DPAD_LEFT);
 }
 
 -(void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
@@ -44,9 +36,9 @@ int dpad_or_btn = 0;
     //	[event allTouches];
     
     if (dpad_or_btn &1)
-        kcode[0] |= (key_CONT_START|key_CONT_A);
+        kcode[0] |= (DC_BTN_START|DC_BTN_A);
     else
-        kcode[0] |= (key_CONT_DPAD_LEFT);
+        kcode[0] |= (DC_BTN_DPAD_LEFT);
     
     dpad_or_btn++;
 }

--- a/shell/apple/emulator-ios/emulator/ios_main.mm
+++ b/shell/apple/emulator-ios/emulator/ios_main.mm
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include "hw/sh4/dyna/blockmanager.h"
+#include "hw/maple/maple_controller.h"
 #include <unistd.h>
 
 
@@ -54,11 +55,6 @@ int darw_printf(const wchar* text,...) {
 void common_linux_setup();
 int dc_init(int argc,wchar* argv[]);
 void dc_run();
-
-u16 kcode[4];
-u32 vks[4];
-s8 joyx[4],joyy[4];
-u8 rt[4],lt[4];
 
 extern "C" int reicast_main(int argc, wchar* argv[])
 {

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -8,6 +8,7 @@
 #import <Carbon/Carbon.h>
 
 #include "types.h"
+#include "hw/maple/maple_controller.h"
 #include <sys/stat.h>
 
 #include <OpenGL/gl3.h>
@@ -37,11 +38,6 @@ int darw_printf(const wchar* text,...) {
     
     return 0;
 }
-
-u16 kcode[4] = { 0xFFFF };
-u32 vks[4];
-s8 joyx[4],joyy[4];
-u8 rt[4],lt[4];
 
 int get_mic_data(u8* buffer) { return 0; }
 int push_vmu_screen(u8* buffer) { return 0; }
@@ -135,30 +131,6 @@ extern "C" void emu_gles_init() {
     gles_init();
 }
 
-enum DCPad {
-    Btn_C		= 1,
-    Btn_B		= 1<<1,
-    Btn_A		= 1<<2,
-    Btn_Start	= 1<<3,
-    DPad_Up		= 1<<4,
-    DPad_Down	= 1<<5,
-    DPad_Left	= 1<<6,
-    DPad_Right	= 1<<7,
-    Btn_Z		= 1<<8,
-    Btn_Y		= 1<<9,
-    Btn_X		= 1<<10,
-    Btn_D		= 1<<11,
-    DPad2_Up	= 1<<12,
-    DPad2_Down	= 1<<13,
-    DPad2_Left	= 1<<14,
-    DPad2_Right	= 1<<15,
-    
-    Axis_LT= 0x10000,
-    Axis_RT= 0x10001,
-    Axis_X= 0x20000,
-    Axis_Y= 0x20001,
-};
-
 void handle_key(int dckey, int state) {
     if (state)
         kcode[0] &= ~dckey;
@@ -176,18 +148,18 @@ void handle_trig(u8* dckey, int state) {
 extern "C" void emu_key_input(char* keyt, int state) {
     int key = keyt[0];
     switch(key) {
-        case 'z':     handle_key(Btn_X, state); break;
-        case 'x':     handle_key(Btn_Y, state); break;
-        case 'c':     handle_key(Btn_B, state); break;
-        case 'v':     handle_key(Btn_A, state); break;
+        case 'z':     handle_key(DC_BTN_X, state); break;
+        case 'x':     handle_key(DC_BTN_Y, state); break;
+        case 'c':     handle_key(DC_BTN_B, state); break;
+        case 'v':     handle_key(DC_BTN_A, state); break;
         
         case 'a':     handle_trig(lt, state); break;
         case 's':     handle_trig(rt, state); break;
             
-        case 'j':     handle_key(DPad_Left, state); break;
-        case 'k':     handle_key(DPad_Down, state); break;
-        case 'l':     handle_key(DPad_Right, state); break;
-        case 'i':     handle_key(DPad_Up, state); break;
-        case 0xa:     handle_key(Btn_Start, state); break;
+        case 'j':     handle_key(DC_BTN_DPAD_LEFT,  state); break;
+        case 'k':     handle_key(DC_BTN_DPAD_DOWN,  state); break;
+        case 'l':     handle_key(DC_BTN_DPAD_RIGHT, state); break;
+        case 'i':     handle_key(DC_BTN_DPAD_UP,    state); break;
+        case 0xa:     handle_key(DC_BTN_START,      state); break;
     }
 }

--- a/shell/apple/emulator-osx/emulator-osx/osx-main.mm
+++ b/shell/apple/emulator-osx/emulator-osx/osx-main.mm
@@ -133,9 +133,9 @@ extern "C" void emu_gles_init() {
 
 void handle_key(int dckey, int state) {
     if (state)
-        kcode[0] &= ~dckey;
+        maple_controller[0].buttons &= ~dckey;
     else
-        kcode[0] |= dckey;
+        maple_controller[0].buttons |= dckey;
 }
 
 void handle_trig(u8* dckey, int state) {

--- a/shell/reicast.vcxproj
+++ b/shell/reicast.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="..\core\hw\holly\sb_dma.cpp" />
     <ClCompile Include="..\core\hw\holly\sb_mem.cpp" />
     <ClCompile Include="..\core\hw\maple\maple_cfg.cpp" />
+    <ClCompile Include="..\core\hw\maple\maple_controller.cpp" />
     <ClCompile Include="..\core\hw\maple\maple_devs.cpp" />
     <ClCompile Include="..\core\hw\maple\maple_helper.cpp" />
     <ClCompile Include="..\core\hw\maple\maple_if.cpp" />


### PR DESCRIPTION
~~This PR is still a work in progress, so expect rebasing/force-pushing to this branch.~~ If you have any concers about this, you can comment here :D

What this does:
- Removes 113 lines of duplicated code
- Makes it possible to enable specific ports (like port 1 and 3, but not 2 and 4). Current behaviour remains unchanged (only port 1 is enabled at the moment)
- Groups `kcode`, `joyx`, `joyy`, `lt` and `rt` together (since they belong together anyway) and gives them a more meaningful name

This might be useful anyway, but if we also merged #820, we could enable/disable ports before calling `dc_init()` based on what devices are configured and connected to the host OS.
