### PR TITLE
Move to SDL2 for OpenGL 3.1 and GLES support

### DIFF
--- a/core/khronos/GL3/gl3w.c
+++ b/core/khronos/GL3/gl3w.c
@@ -1,6 +1,25 @@
 #include <GL3/gl3w.h>
 
-#ifdef _WIN32
+#if defined(USE_SDL2)
+	#include <SDL2/SDL.h>
+	static void open_libgl(void)
+	{
+		SDL_GL_LoadLibrary(NULL);
+	}
+
+	static void close_libgl(void)
+	{
+		SDL_GL_UnloadLibrary();
+	}
+
+	static void *get_proc(const char *proc)
+	{
+		void *res = NULL;
+		res = (void*)SDL_GL_GetProcAddress(proc);
+		return res;
+	}
+
+#elif defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
 

--- a/core/khronos/GL3/gl3w.c
+++ b/core/khronos/GL3/gl3w.c
@@ -1,6 +1,6 @@
 #include <GL3/gl3w.h>
 
-#if defined(USE_SDL2)
+#if defined(USE_SDL)
 	#include <SDL2/SDL.h>
 	static void open_libgl(void)
 	{

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -355,7 +355,7 @@ int screen_width;
 int screen_height;
 
 #if (HOST_OS != OS_DARWIN) && !defined(TARGET_NACL32)
-#ifdef GLES
+#if defined(GLES) && !defined(USE_SDL)
 	// Create a basic GLES context
 	bool gl_init(void* wind, void* disp)
 	{

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -5,6 +5,18 @@
 #include "sdl/sdl.h"
 #ifdef GLES
 	#include <EGL/egl.h>
+#else
+	#ifndef USE_SDL2
+		#error "Our SDL1.2 implementation only supports GLES. You need SDL2 for OpenGL 3 support!"
+	#endif
+	#include "khronos/GL3/gl3w.h"
+#endif
+
+#ifdef USE_SDL2
+	static SDL_Window* window = NULL;
+	static SDL_GLContext glcontext;
+#else
+	SDL_Surface *screen = NULL;
 #endif
 
 #ifdef TARGET_PANDORA
@@ -13,8 +25,6 @@
 	#define WINDOW_WIDTH  640
 #endif
 #define WINDOW_HEIGHT  480
-
-SDL_Surface *screen = NULL;
 
 static SDL_Joystick *JoySDL = 0;
 
@@ -80,11 +90,15 @@ void input_sdl_init()
 
 		AxisCount = SDL_JoystickNumAxes(JoySDL);
 		ButtonCount = SDL_JoystickNumButtons(JoySDL);
-		Name = SDL_JoystickName(0);
-		
+		#ifdef USE_SDL2
+			Name = SDL_JoystickName(JoySDL);
+		#else
+			Name = SDL_JoystickName(0);
+		#endif
+
 		printf("SDK: Found '%s' joystick with %d axes and %d buttons\n", Name, AxisCount, ButtonCount);
 
-		if (strcmp(Name,"Microsoft X-Box 360 pad")==0)
+		if (Name != NULL && strcmp(Name,"Microsoft X-Box 360 pad")==0)
 		{
 			sdl_map_btn  = sdl_map_btn_xbox360;
 			sdl_map_axis = sdl_map_axis_xbox360;
@@ -113,12 +127,16 @@ void input_sdl_init()
 		}
 	#endif
 	
-	SDL_ShowCursor(0);
+	#ifndef USE_SDL2
+		SDL_ShowCursor(0);
 
-	if (SDL_WM_GrabInput( SDL_GRAB_ON ) != SDL_GRAB_ON)
-	{
-		printf("SDK: Error while grabbing mouse\n");
-	}
+		if (SDL_WM_GrabInput( SDL_GRAB_ON ) != SDL_GRAB_ON)
+		{
+			printf("SDL: Error while grabbing mouse\n");
+		}
+	#else
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+	#endif
 }
 
 void input_sdl_handle(u32 port)
@@ -397,7 +415,14 @@ void sdl_window_set_text(const char* text)
 	#ifdef TARGET_PANDORA
 		strncpy(OSD_Counters, text, 256);
 	#else
-		SDL_WM_SetCaption(text, NULL);    // *TODO*  Set Icon also...
+		#ifdef USE_SDL2
+			if(window)
+			{
+				SDL_SetWindowTitle(window, text);    // *TODO*  Set Icon also...
+			}
+		#else
+			SDL_WM_SetCaption(text, NULL);
+		#endif
 	#endif
 }
 
@@ -415,17 +440,79 @@ void sdl_window_create()
 
 	int window_width  = cfgLoadInt("x11","width", WINDOW_WIDTH);
 	int window_height = cfgLoadInt("x11","height", WINDOW_HEIGHT);
+
 	#ifdef TARGET_PANDORA
 		int flags = SDL_FULLSCREEN;
 	#else
 		int flags = SDL_SWSURFACE;
 	#endif
-	screen = SDL_SetVideoMode(window_width, window_height, 0, flags);
-	if (!screen)
-	{
-		die("error creating SDL screen");
-	}
-	x11_disp = EGL_DEFAULT_DISPLAY;
-	printf("Created SDL Windows (%ix%i) successfully\n", window_width, window_height);
+
+	#if !defined(GLES) && defined(USE_SDL2)
+		flags |= SDL_WINDOW_OPENGL;
+
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+		SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+		SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+		SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+		SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+		window = SDL_CreateWindow("Reicast Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,	window_width, window_height, flags);
+		if (!window)
+		{
+			die("error creating SDL window");
+		}
+
+		glcontext = SDL_GL_CreateContext(window);
+		if (!glcontext)
+		{
+			die("Error creating SDL GL context");
+		}
+		SDL_GL_MakeCurrent(window, NULL);
+	#else
+		screen = SDL_SetVideoMode(window_width, window_height, 0, flags);
+		if (!screen)
+		{
+			die("error creating SDL screen");
+		}
+
+		x11_disp = EGL_DEFAULT_DISPLAY;
+	#endif
+
+	printf("Created SDL Window (%ix%i) and GL Context successfully\n", window_width, window_height);
 }
+#endif
+
+#if !defined(GLES) && defined(USE_SDL2)
+	extern int screen_width, screen_height;
+
+	bool gl_init(void* wind, void* disp)
+	{
+		SDL_GL_MakeCurrent(window, glcontext);
+		return gl3wInit() != -1 && gl3wIsSupported(3, 1);
+	}
+
+	void gl_swap()
+	{
+		SDL_GL_SwapWindow(window);
+
+		/* Check if drawable has been resized */
+		int new_width, new_height;
+		SDL_GL_GetDrawableSize(window, &new_width, &new_height);
+
+		if (new_width != screen_width || new_height != screen_height)
+		{
+			screen_width = new_width;
+			screen_height = new_height;
+		}
+	}
+
+	void gl_term()
+	{
+		SDL_GL_DeleteContext(glcontext);
+	}
 #endif

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -3,21 +3,13 @@
 #include "cfg/cfg.h"
 #include "linux-dist/main.h"
 #include "sdl/sdl.h"
-#ifdef GLES
-	#include <EGL/egl.h>
-#else
-	#ifndef USE_SDL2
-		#error "Our SDL1.2 implementation only supports GLES. You need SDL2 for OpenGL 3 support!"
-	#endif
-	#include "khronos/GL3/gl3w.h"
+#ifndef GLES
+#include "khronos/GL3/gl3w.h"
+#endif
 #endif
 
-#ifdef USE_SDL2
-	static SDL_Window* window = NULL;
-	static SDL_GLContext glcontext;
-#else
-	SDL_Surface *screen = NULL;
-#endif
+static SDL_Window* window = NULL;
+static SDL_GLContext glcontext;
 
 #ifdef TARGET_PANDORA
 	#define WINDOW_WIDTH  800
@@ -26,7 +18,7 @@
 #endif
 #define WINDOW_HEIGHT  480
 
-static SDL_Joystick *JoySDL = 0;
+static SDL_Joystick* JoySDL = 0;
 
 extern bool FrameSkipping;
 extern void dc_term();
@@ -90,11 +82,7 @@ void input_sdl_init()
 
 		AxisCount = SDL_JoystickNumAxes(JoySDL);
 		ButtonCount = SDL_JoystickNumButtons(JoySDL);
-		#ifdef USE_SDL2
-			Name = SDL_JoystickName(JoySDL);
-		#else
-			Name = SDL_JoystickName(0);
-		#endif
+		Name = SDL_JoystickName(JoySDL);
 
 		printf("SDK: Found '%s' joystick with %d axes and %d buttons\n", Name, AxisCount, ButtonCount);
 
@@ -127,16 +115,7 @@ void input_sdl_init()
 		}
 	#endif
 	
-	#ifndef USE_SDL2
-		SDL_ShowCursor(0);
-
-		if (SDL_WM_GrabInput( SDL_GRAB_ON ) != SDL_GRAB_ON)
-		{
-			printf("SDL: Error while grabbing mouse\n");
-		}
-	#else
-		SDL_SetRelativeMouseMode(SDL_TRUE);
-	#endif
+	SDL_SetRelativeMouseMode(SDL_TRUE);
 }
 
 void input_sdl_handle(u32 port)
@@ -415,14 +394,10 @@ void sdl_window_set_text(const char* text)
 	#ifdef TARGET_PANDORA
 		strncpy(OSD_Counters, text, 256);
 	#else
-		#ifdef USE_SDL2
-			if(window)
-			{
-				SDL_SetWindowTitle(window, text);    // *TODO*  Set Icon also...
-			}
-		#else
-			SDL_WM_SetCaption(text, NULL);
-		#endif
+		if(window)
+		{
+			SDL_SetWindowTitle(window, text);    // *TODO*  Set Icon also...
+		}
 	#endif
 }
 
@@ -441,78 +416,75 @@ void sdl_window_create()
 	int window_width  = cfgLoadInt("x11","width", WINDOW_WIDTH);
 	int window_height = cfgLoadInt("x11","height", WINDOW_HEIGHT);
 
+	int flags = SDL_WINDOW_OPENGL;
 	#ifdef TARGET_PANDORA
-		int flags = SDL_FULLSCREEN;
+		flags |= SDL_FULLSCREEN;
 	#else
-		int flags = SDL_SWSURFACE;
+		flags |= SDL_SWSURFACE;
 	#endif
 
-	#if !defined(GLES) && defined(USE_SDL2)
-		flags |= SDL_WINDOW_OPENGL;
-
+	#ifdef GLES
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	#else
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
-		SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
-		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-
-		window = SDL_CreateWindow("Reicast Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,	window_width, window_height, flags);
-		if (!window)
-		{
-			die("error creating SDL window");
-		}
-
-		glcontext = SDL_GL_CreateContext(window);
-		if (!glcontext)
-		{
-			die("Error creating SDL GL context");
-		}
-		SDL_GL_MakeCurrent(window, NULL);
-	#else
-		screen = SDL_SetVideoMode(window_width, window_height, 0, flags);
-		if (!screen)
-		{
-			die("error creating SDL screen");
-		}
-
-		x11_disp = EGL_DEFAULT_DISPLAY;
 	#endif
+
+	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+
+	window = SDL_CreateWindow("Reicast Emulator", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,	window_width, window_height, flags);
+	if (!window)
+	{
+		die("error creating SDL window");
+	}
+
+	glcontext = SDL_GL_CreateContext(window);
+	if (!glcontext)
+	{
+		die("Error creating SDL GL context");
+	}
+	SDL_GL_MakeCurrent(window, NULL);
 
 	printf("Created SDL Window (%ix%i) and GL Context successfully\n", window_width, window_height);
 }
-#endif
 
-#if !defined(GLES) && defined(USE_SDL2)
-	extern int screen_width, screen_height;
+extern int screen_width, screen_height;
 
-	bool gl_init(void* wind, void* disp)
-	{
-		SDL_GL_MakeCurrent(window, glcontext);
+bool gl_init(void* wind, void* disp)
+{
+	SDL_GL_MakeCurrent(window, glcontext);
+	#ifdef GLES
+		return true;
+	#else
 		return gl3wInit() != -1 && gl3wIsSupported(3, 1);
-	}
+	#endif
+}
 
-	void gl_swap()
+void gl_swap()
+{
+	SDL_GL_SwapWindow(window);
+
+	/* Check if drawable has been resized */
+	int new_width, new_height;
+	SDL_GL_GetDrawableSize(window, &new_width, &new_height);
+
+	if (new_width != screen_width || new_height != screen_height)
 	{
-		SDL_GL_SwapWindow(window);
-
-		/* Check if drawable has been resized */
-		int new_width, new_height;
-		SDL_GL_GetDrawableSize(window, &new_width, &new_height);
-
-		if (new_width != screen_width || new_height != screen_height)
-		{
-			screen_width = new_width;
-			screen_height = new_height;
-		}
+		screen_width = new_width;
+		screen_height = new_height;
 	}
+}
 
-	void gl_term()
-	{
-		SDL_GL_DeleteContext(glcontext);
-	}
-#endif
+void gl_term()
+{
+	SDL_GL_DeleteContext(glcontext);
+}

--- a/core/sdl/sdl.cpp
+++ b/core/sdl/sdl.cpp
@@ -401,8 +401,6 @@ void sdl_window_set_text(const char* text)
 	#endif
 }
 
-int ndcid = 0;
-
 void sdl_window_create()
 {
 	if (SDL_WasInit(SDL_INIT_VIDEO) == 0)

--- a/core/sdl/sdl.h
+++ b/core/sdl/sdl.h
@@ -1,5 +1,9 @@
 #pragma once
-#include <SDL/SDL.h>
+#ifdef USE_SDL2
+	#include <SDL2/SDL.h>
+#else
+	#include <SDL/SDL.h>
+#endif
 extern void* sdl_glc;
 extern void input_sdl_init();
 extern void input_sdl_handle(u32 port);

--- a/core/sdl/sdl.h
+++ b/core/sdl/sdl.h
@@ -1,9 +1,6 @@
 #pragma once
-#ifdef USE_SDL2
-	#include <SDL2/SDL.h>
-#else
-	#include <SDL/SDL.h>
-#endif
+#include <SDL2/SDL.h>
+
 extern void* sdl_glc;
 extern void input_sdl_init();
 extern void input_sdl_handle(u32 port);

--- a/core/sdl/sdl.h
+++ b/core/sdl/sdl.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <SDL2/SDL.h>
 
-extern void* sdl_glc;
 extern void input_sdl_init();
 extern void input_sdl_handle(u32 port);
 extern void sdl_window_create();

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -175,6 +175,10 @@ else
     $(error Unknown platform)
 endif
 
+ifdef USE_SDL2
+    USE_SDL := 1
+endif
+
 RZDCY_SRC_DIR = ../../core
 include $(RZDCY_SRC_DIR)/core.mk
 
@@ -202,8 +206,14 @@ ifndef NOT_ARM
 endif
 
 ifdef USE_SDL
-    CXXFLAGS += `sdl-config --cflags` -D USE_SDL
-    LIBS += `sdl-config --libs`
+    CXXFLAGS += -D USE_SDL
+    ifdef USE_SDL2
+        CXXFLAGS += `sdl2-config --cflags` -D USE_SDL2
+        LIBS += `sdl2-config --libs`
+    else
+        CXXFLAGS += `sdl-config --cflags`
+        LIBS += `sdl-config --libs`
+    endif
 endif
 
 ifdef PGO_MAKE

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -175,10 +175,6 @@ else
     $(error Unknown platform)
 endif
 
-ifdef USE_SDL2
-    USE_SDL := 1
-endif
-
 RZDCY_SRC_DIR = ../../core
 include $(RZDCY_SRC_DIR)/core.mk
 
@@ -206,14 +202,8 @@ ifndef NOT_ARM
 endif
 
 ifdef USE_SDL
-    CXXFLAGS += -D USE_SDL
-    ifdef USE_SDL2
-        CXXFLAGS += `sdl2-config --cflags` -D USE_SDL2
-        LIBS += `sdl2-config --libs`
-    else
-        CXXFLAGS += `sdl-config --cflags`
-        LIBS += `sdl-config --libs`
-    endif
+    CXXFLAGS += `sdl2-config --cflags` -D USE_SDL
+    LIBS += `sdl2-config --libs`
 endif
 
 ifdef PGO_MAKE


### PR DESCRIPTION
~~Unfortunately, I needed to move to SDL2 to make this work. I'm not really happy with introducing yet another code path, so we should decide if we want to keep SDL1.2 support (without OpenGL3) or if we wan't to move to SDL2.~~

**EDIT:** What this PR does:
- Migrate from SDL1.2 to SDL2 and drop SDL1.2 support
- We can now initialize the OpenGL 3.1 context in a platform-independent way via SDL2 (SDL1.2 did not support OpenGL 3.1)
- OpenGL ES is also initialized via SDL2 instead of using custom EGL code (it's still there for Android though, but maybe we can also use SDL2 on Android?).

As a Bonus, I can now run reicast with OpenGL ES on my Linux desktop (the egl code always failed, but via SDL2 it works fine).