### PR TITLE
Linux/reicast-joyconfig: Fix error handling for Python < 3.0

### DIFF
--- a/shell/linux/tools/reicast-joyconfig.py
+++ b/shell/linux/tools/reicast-joyconfig.py
@@ -45,9 +45,11 @@ def clear_events(dev):
         event = dev.read_one()
         while(event is not None):
             event = dev.read_one()
-    except BlockingIOError:
+    except (OSError, IOError):
         # BlockingIOErrors should only occur if someone uses the evdev
-        # module < v0.4.4
+        # module < v0.4.4. BlockingIOError inherits from OSError, so we
+        # catch that for Python 2 compatibility. We also catch IOError,
+        # just in case.
         pass
 
 


### PR DESCRIPTION
This should fix the bug described in https://github.com/reicast/reicast-emulator/issues/427#issuecomment-141253833.