### PR TITLE
Set HOST_CPU for TARGET_OSX to CPU_X64

### DIFF
--- a/core/build.h
+++ b/core/build.h
@@ -198,7 +198,7 @@
     #define HOST_CPU CPU_ARM
 #elif defined(TARGET_OSX)
     #define HOST_OS OS_DARWIN
-    #define HOST_CPU CPU_GENERIC
+    #define HOST_CPU CPU_X64
 #else
 	#error Invalid Target: TARGET_* not defined
 #endif


### PR DESCRIPTION
Set the CPU for OS X to x64. CPU_GENERIC seems unusable and has timing issues for me so that's why I'm recommending this be changed to CPU_X64. This should also be okay because all recent versions of OS X (staring with 10.7) are x64 only anyways. If there's a reason not to do this let me know because I'd like to not have to maintain a fork and merge changes with upstream for OpenEmu.