### PR TITLE
Fix the check for the enviroment variable

### DIFF
--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -347,7 +347,7 @@ string find_user_data_dir()
 std::vector<string> find_system_config_dirs()
 {
 	std::vector<string> dirs;
-	if (getenv("XDG_DATA_DIRS") != NULL)
+	if (getenv("XDG_CONFIG_DIRS") != NULL)
 	{
 		string s = (string)getenv("XDG_CONFIG_DIRS");
 


### PR DESCRIPTION
I tried running reicast and it immediately died with:

terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_S_construct null not valid
Aborted

I was missing the environment variable XDG_CONFIG_DIRS

Turns out find_system_config_dirs() checked for the existence of
XDG_DATA_DIRS but then tried to use XDG_CONFIG_DIRS (non-existent in my
case).

fixes #847