### PR TITLE
Fix some buffer overflows

### DIFF
--- a/core/cfg/cfg.cpp
+++ b/core/cfg/cfg.cpp
@@ -128,6 +128,7 @@ s32  cfgExists(const wchar * Section, const wchar * Key)
 void  cfgLoadStr(const wchar * Section, const wchar * Key, wchar * Return,const wchar* Default)
 {
 	string value = cfgdb.get(Section, Key, Default);
+	// FIXME: Buffer overflow possible
 	strcpy(Return, value.c_str());
 }
 

--- a/core/cfg/ini.cpp
+++ b/core/cfg/ini.cpp
@@ -221,7 +221,11 @@ void ConfigFile::parse(FILE* file)
 		if (tl[0] == '[' && tl[strlen(tl)-1] == ']')
 		{
 			tl[strlen(tl)-1] = '\0';
-			strcpy(current_section, tl+1);
+
+			// FIXME: Data loss if buffer is too small
+			strncpy(current_section, tl+1, sizeof(current_section));
+			current_section[sizeof(current_section) - 1] = '\0';
+
 			trim_ws(current_section);
 		}
 		else

--- a/core/hw/flashrom/flashrom.h
+++ b/core/hw/flashrom/flashrom.h
@@ -63,7 +63,11 @@ struct MemChip
 		wchar base[512];
 		wchar temp[512];
 		wchar names[512];
-		strcpy(names,names_ro.c_str());
+
+		// FIXME: Data loss if buffer is too small
+		strncpy(names,names_ro.c_str(), sizeof(names));
+		names[sizeof(names) - 1] = '\0';
+
 		sprintf(base,"%s",root.c_str());
 
 		wchar* curr=names;

--- a/core/hw/naomi/naomi_cart.cpp
+++ b/core/hw/naomi/naomi_cart.cpp
@@ -32,8 +32,11 @@ bool naomi_cart_LoadRom(char* file)
 
 	folder_pos++;
 
+	// FIXME: Data loss if buffer is too small
 	char t[512];
-	strcpy(t, file);
+	strncpy(t, file, sizeof(t));
+	t[sizeof(t) - 1] = '\0';
+
 	FILE* fl = fopen(t, "r");
 	if (!fl)
 		return false;
@@ -92,7 +95,10 @@ bool naomi_cart_LoadRom(char* file)
 	RomCacheMapCount = (u32)files.size();
 	RomCacheMap = new fd_t[files.size()];
 
-	strcpy(t, file);
+	// FIXME: Data loss if buffer is too small
+	strncpy(t, file, sizeof(t));
+	t[sizeof(t) - 1] = '\0';
+
 	t[folder_pos] = 0;
 	strcat(t, "ndcn-composed.cache");
 
@@ -106,7 +112,9 @@ bool naomi_cart_LoadRom(char* file)
 	verify(RomPtr != 0);
 	verify(RomPtr != (void*)-1);
 
-	strcpy(t, file);
+	// FIXME: Data loss if buffer is too small
+	strncpy(t, file, sizeof(t));
+	t[sizeof(t) - 1] = '\0';
 
 	//Create File Mapping Objects
 	for (size_t i = 0; i<files.size(); i++)

--- a/core/imgread/common.cpp
+++ b/core/imgread/common.cpp
@@ -178,8 +178,11 @@ bool InitDrive(u32 fileflags)
 			return true;
 	}
 
+	// FIXME: Data loss if buffer is too small
 	wchar fn[512];
-	strcpy(fn,settings.imgread.LastImage);
+	strncpy(fn,settings.imgread.LastImage, sizeof(fn));
+	fn[sizeof(fn) - 1] = '\0';
+
 #ifdef BUILD_DREAMCAST
 	int gfrv=GetFile(fn,0,fileflags);
 #else
@@ -199,7 +202,10 @@ bool InitDrive(u32 fileflags)
 		return false;
 	}
 
-	strcpy(settings.imgread.LastImage,fn);
+	// FIXME: Data loss if buffer is too small
+	strncpy(settings.imgread.LastImage, fn, sizeof(settings.imgread.LastImage));
+	settings.imgread.LastImage[sizeof(settings.imgread.LastImage) - 1] = '\0';
+
 	SaveSettings();
 
 	if (!InitDrive_(fn))
@@ -232,8 +238,12 @@ bool DiscSwap(u32 fileflags)
 			return true;
 	}
 
+	// FIXME: Data loss if buffer is too small
 	wchar fn[512];
-	strcpy(fn,settings.imgread.LastImage);
+	strncpy(fn, settings.imgread.LastImage, sizeof(fn));
+	fn[sizeof(fn) - 1] = '\0';
+
+
 #ifdef BUILD_DREAMCAST
 	int gfrv=GetFile(fn,0,fileflags);
 #else
@@ -256,7 +266,11 @@ bool DiscSwap(u32 fileflags)
 		return false;
 	}
 
-	strcpy(settings.imgread.LastImage,fn);
+	// FIXME: Data loss if buffer is too small
+	strncpy(settings.imgread.LastImage, fn, sizeof(settings.imgread.LastImage));
+	settings.imgread.LastImage[sizeof(settings.imgread.LastImage) - 1] = '\0';
+
+
 	SaveSettings();
 
 	if (!InitDrive_(fn))

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -31,9 +31,13 @@ Disc* load_gdi(const char* file)
 	gdi >> iso_tc;
 	printf("\nGDI : %d tracks\n",iso_tc);
 
+	// FIXME: Data loss if buffer is too small
 	char path[512];
-	strcpy(path,file);
-	size_t len=strlen(file);
+	strncpy(path, file, sizeof(path));
+	path[sizeof(path) - 1] = '\0';
+
+	size_t len = strlen(path);
+
 	while (len>2)
 	{
 		if (path[len]=='\\' || path[len]=='/')

--- a/core/webui/server.cpp
+++ b/core/webui/server.cpp
@@ -288,7 +288,11 @@ static int callback_http(struct libwebsocket_context *context,
 		}
 
 		/* if not, send a file the easy way */
-		strcpy(buf, resource_path);
+
+		// FIXME: Data loss if buffer is too small
+		strncpy(buf, resource_path, sizeof(buf));
+		buf[sizeof(buf) - 1] = '\0';
+
 		if (strcmp((const char*)in, "/")) {
 			if (*((const char *)in) != '/')
 				strcat(buf, "/");


### PR DESCRIPTION
This fixes some buffer overflows, which might lead to crashes or even compromise security. Please note that not all fixes actually can be used right now (e.g. b106efde5f6254bdd3cd81251cb94a8891e63710, where both buffers are currently of equal size), but using `strncpy` instead of `strcpy` is probably a good idea anyway to prevent issues if buffer sizes are changed later.

I didn't fix the obvious buffer overflow in `cfg/cfg.cpp`, since we'd need to change the function signature which makes more code changes necessary - and I'm out of free time currently.
