### PR TITLE
Add an option to core.mk to build android without webui if wanted

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -111,4 +111,8 @@ ifdef HAS_SOFTREND
 	RZDCY_CFLAGS += -DTARGET_SOFTREND
 endif
 
+ifndef WEBUI
+	RZDCY_CFLAGS += -DTARGET_NO_WEBUI
+endif
+
 RZDCY_CXXFLAGS := $(RZDCY_CFLAGS) -fno-exceptions -fno-rtti -std=gnu++11


### PR DESCRIPTION
Remove the line "WEBUI := 1" from Android.mk to test.