### PR TITLE
linux-dist/evdev: Use std::Map.find() instead of operator[]

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -285,7 +285,7 @@
 						return -3;
 					}
 				}
-				controller->mapping = &loaded_mappings[string(mapping_fname)];
+				controller->mapping = &loaded_mappings.find(string(mapping_fname))->second;
 				printf("evdev: Using '%s' mapping\n", controller->mapping->name);
 				controller->init();
 


### PR DESCRIPTION
Since EvdevControllerMapping does not have a default constructor,
we can't use the operator[];

    data_type& operator[](const key_type& k) - Returns a reference to
    the object that is associated with a particular key. If the map
    does not already contain such an object, operator[] inserts the
    default object data_type().

Instead, we use the std::map.find() function.