### PR TITLE
alsa-backend: initialize variable "sub unit dir"

### DIFF
--- a/core/oslib/audiobackend_alsa.cpp
+++ b/core/oslib/audiobackend_alsa.cpp
@@ -13,7 +13,7 @@ static void alsa_init()
 
 	snd_pcm_hw_params_t *params;
 	unsigned int val;
-	int dir;
+	int dir=-1;
 	snd_pcm_uframes_t frames;
 
 	/* Open PCM device for playback. */


### PR DESCRIPTION
Really minimal change to fix alsa initialization in some environments:

This variable is passed into alsa as a pointer. Alsa will write to it but also read (!) from it. So the read will give undesired behavior because variable was not initialized. Depending on current alsa-config/hardware it leads to an error "Invalid argument" when submitting the parameters by invoking "snd_pcm_hw_params" a few lines later.

Initializing the variable to -1 fixes it and means "set to exact value or less" (http://alsa.opensrc.org/HowTo_Asynchronous_Playback)
