### PR TITLE
Nougat compatibility (requires native updates)

### DIFF
--- a/shell/android/jni/Android.mk
+++ b/shell/android/jni/Android.mk
@@ -61,7 +61,7 @@ ifeq ($(TARGET_ARCH_ABI),x86)
 endif
 
 LOCAL_CPP_FEATURES := 
-LOCAL_SHARED_LIBRARIES:= libcutils libutils
+#LOCAL_SHARED_LIBRARIES:= libcutils libutils
 LOCAL_PRELINK_MODULE  := false
 
 LOCAL_MODULE	:= dc

--- a/shell/android/jni/Application.mk
+++ b/shell/android/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_STL		:= stlport_static
 APP_ABI 	:= armeabi-v7a x86 mips
 #APP_ABI		:= armeabi-v7a
-APP_PLATFORM	:= android-19
+APP_PLATFORM	:= android-21
 #NDK_TOOLCHAIN_VERSION := 4.8

--- a/shell/android/src/com/reicast/emulator/GL2JNIActivity.java
+++ b/shell/android/src/com/reicast/emulator/GL2JNIActivity.java
@@ -77,6 +77,12 @@ public class GL2JNIActivity extends Activity {
 		 * catch (IOException e) { e.getMessage(); e.printStackTrace(); }
 		 */
 		
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			pad.compat[0] = true;
+			pad.compat[1] = true;
+			pad.compat[2] = true;
+			pad.compat[3] = true;
+		}
 
 		String fileName = null;
 


### PR DESCRIPTION
While the current x86 ASM is incompatible with the newest NDK, this will make the build configuration compatible and provide workarounds for functionality.