### PR TITLE
Fix hardware detection for Odroid-XU4 against newer kernels

### DIFF
--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -44,6 +44,8 @@ ifeq (,$(platform))
             platform = odroidc1
         else ifneq (,$(findstring ODROID-XU3,$(HARDWARE)))
             platform = odroidxu3
+	else ifneq (,$(findstring ODROID-XU4,$(HARDWARE)))
+            platform = odroidxu3
         else ifneq (,$(findstring ODROIDXU,$(HARDWARE)))
             platform = odroidxu
         else ifneq (,$(findstring ODROIDX2,$(HARDWARE)))


### PR DESCRIPTION
On older kernels, the Odroid-XU4 would be identified as "ODROID-XU3". On newer kernels, such as the latest Ubuntu kernel for ODroid, the XU4 is now being identifed as "ODROID-XU4" which would cause the hardware detection to fail and have it build a generic ARM build instead of our desired "platform = odroidxu3".