### PR TITLE
configuration parsing: get_entry must not look into virtual sections …

### DIFF
--- a/core/cfg/ini.cpp
+++ b/core/cfg/ini.cpp
@@ -111,7 +111,7 @@ ConfigSection* ConfigFile::get_section(string name, bool is_virtual)
 ConfigEntry* ConfigFile::get_entry(string section_name, string entry_name)
 {
 	ConfigSection* section = this->get_section(section_name, true);
-	if(section != NULL)
+	if(section != NULL && section->has_entry(entry_name))
 	{
 		return section->get_entry(entry_name);
 	}


### PR DESCRIPTION
configuration parsing: get_entry must not look into virtual sections only

in emu.cfg, when i set rend.WideScreen = 1, its not read.
has_entry and get_entry doesn't use the same check,
thus while has_entry can return true, get_entry can not return the entry.

in my case :

ConfigSection* section = this->get_section(section_name, true);
if(section != NULL && section->has_entry(entry_name)) => returns now false

ConfigSection* section = this->get_section(section_name, true);
if(section != NULL) => can now returns true

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>