### PR TITLE
Build on FreeBSD

### DIFF
--- a/core/linux-dist/joystick.cpp
+++ b/core/linux-dist/joystick.cpp
@@ -1,10 +1,11 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include <linux/joystick.h>
 #include "linux-dist/joystick.h"
 
 #if defined(USE_JOYSTICK)
+#include <linux/joystick.h>
+
 	const u32 joystick_map_btn_usb[JOYSTICK_MAP_SIZE]      = { DC_BTN_Y, DC_BTN_B, DC_BTN_A, DC_BTN_X, 0, 0, 0, 0, 0, DC_BTN_START };
 	const u32 joystick_map_axis_usb[JOYSTICK_MAP_SIZE]     = { DC_AXIS_X, DC_AXIS_Y, 0, 0, 0, 0, 0, 0, 0, 0 };
 

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -18,7 +18,7 @@
 #include <sys/param.h>
 #include <sys/mman.h>
 #include <sys/time.h>
-#if !defined(_ANDROID) && !defined(TARGET_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_OSX)
+#if !defined(TARGET_BSD) && !defined(_ANDROID) && !defined(TARGET_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_OSX)
   #include <sys/personality.h>
   #include <dlfcn.h>
 #endif
@@ -294,7 +294,7 @@ void enable_runfast()
 }
 
 void linux_fix_personality() {
-        #if HOST_OS == OS_LINUX && !defined(_ANDROID) && !defined(TARGET_OS_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN)
+        #if !defined(TARGET_BSD) && !defined(_ANDROID) && !defined(TARGET_OS_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN)
           printf("Personality: %08X\n", personality(0xFFFFFFFF));
           personality(~READ_IMPLIES_EXEC & personality(0xFFFFFFFF));
           printf("Updated personality: %08X\n", personality(0xFFFFFFFF));
@@ -302,7 +302,7 @@ void linux_fix_personality() {
 }
 
 void linux_rpi2_init() {
-#if (HOST_OS == OS_LINUX) && !defined(_ANDROID) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN) && defined(TARGET_VIDEOCORE)
+#if !defined(TARGET_BSD) && !defined(_ANDROID) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN) && defined(TARGET_VIDEOCORE)
 	void* handle;
 	void (*rpi_bcm_init)(void);
 

--- a/core/oslib/audiobackend_oss.cpp
+++ b/core/oslib/audiobackend_oss.cpp
@@ -2,7 +2,11 @@
 #ifdef USE_OSS
 #include <sys/ioctl.h>
 #include <sys/fcntl.h>
+#ifdef TARGET_BSD
+#include <unistd.h>
+#else
 #include <sys/unistd.h>
+#endif
 #include <sys/soundcard.h>
 
 static int oss_audio_fd = -1;

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -3,11 +3,9 @@ FOR_LINUX :=1
 #NO_REC := 1
 #NO_REND := 1
 WEBUI :=1 
-USE_ALSA := 1
 USE_OSS := 1
 #USE_PULSEAUDIO := 1
 USE_EVDEV := 1
-USE_JOYSTICK := 1
 
 CXX=${CC_PREFIX}g++
 CC=${CC_PREFIX}gcc
@@ -23,6 +21,13 @@ LIBS :=
 CFLAGS := 
 CXXFLAGS :=
 
+ifneq (, $(filter $(shell uname -s), FreeBSD OpenBSD NetBSD DragonFly))
+    CFLAGS += -DTARGET_BSD
+else
+    USE_ALSA := 1
+    USE_JOYSTICK := 1
+endif
+
 # Platform auto-detection
 # Can be overridden by using:
 #   make platform=x64
@@ -30,7 +35,7 @@ ifeq (,$(platform))
     ARCH = $(shell uname -m)
     ifeq ($(ARCH), $(filter $(ARCH), i386 i686))
         platform = x86
-    else ifeq ($(ARCH), $(filter $(ARCH), x86_64 AMD64))
+    else ifeq ($(ARCH), $(filter $(ARCH), x86_64 AMD64 amd64))
         platform = x64
     else ifneq (,$(findstring aarch64,$(ARCH)))
         HARDWARE = $(shell grep Hardware /proc/cpuinfo)
@@ -281,9 +286,9 @@ ifdef USE_DISPMANX
 endif
 
 ifdef USE_X11
-    CFLAGS += -D SUPPORT_X11
-    CXXFLAGS += -D SUPPORT_X11 
-    LIBS += -lX11
+    CFLAGS += `pkg-config --cflags x11` -D SUPPORT_X11
+    CXXFLAGS += `pkg-config --cflags x11` -D SUPPORT_X11
+    LIBS += `pkg-config --libs x11`
 endif
 
 ifdef USE_EVDEV
@@ -300,8 +305,8 @@ ifdef USE_OMX
 endif
 
 ifdef USE_ALSA
-    CXXFLAGS += -D USE_ALSA
-    LIBS += -lasound
+    CXXFLAGS += `pkg-config --cflags alsa` -D USE_ALSA
+    LIBS += `pkg-config --libs alsa`
 endif
 
 ifdef USE_OSS
@@ -309,8 +314,8 @@ ifdef USE_OSS
 endif
 
 ifdef USE_PULSEAUDIO
-    CXXFLAGS += -D USE_PULSEAUDIO
-    LIBS += -lpulse-simple
+    CXXFLAGS += `pkg-config --cflags libpulse-simple` -D USE_PULSEAUDIO
+    LIBS += `pkg-config --libs libpulse-simple`
 endif
 
 ifdef HAS_SOFTREND
@@ -378,11 +383,11 @@ $(BUILDDIR)/%.build_obj : $(RZDCY_SRC_DIR)/%.S
 	$(AS) $(ASFLAGS) $(INCS) $< -o $@
 
 install: $(EXECUTABLE)
-	mkdir -p $(DESTDIR)$(PREFIX)/bin 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(PREFIX)/share/reicast/mappings 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(MAN_DIR) 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(MENUENTRY_DIR) 2>/dev/null || /bin/true
-	mkdir -p $(DESTDIR)$(ICON_DIR) 2>/dev/null || /bin/true
+	mkdir -p $(DESTDIR)$(PREFIX)/bin 2>/dev/null || true
+	mkdir -p $(DESTDIR)$(PREFIX)/share/reicast/mappings 2>/dev/null || true
+	mkdir -p $(DESTDIR)$(MAN_DIR) 2>/dev/null || true
+	mkdir -p $(DESTDIR)$(MENUENTRY_DIR) 2>/dev/null || true
+	mkdir -p $(DESTDIR)$(ICON_DIR) 2>/dev/null || true
 	install -m755 $(EXECUTABLE) $(DESTDIR)$(PREFIX)/bin/$(EXECUTABLE_NAME)
 	install -m755 tools/reicast-joyconfig.py $(DESTDIR)$(PREFIX)/bin/reicast-joyconfig
 	install -m644 mappings/controller_gcwz.cfg $(DESTDIR)$(PREFIX)/share/reicast/mappings

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,7 +4,7 @@ build:
     steps:
         - script:
             name: install-dependencies
-            code: sudo apt-get clean && sudo apt-get update && sudo apt-get install -y build-essential libasound2-dev libgl1-mesa-dev libx11-dev
+            code: sudo apt-get clean && sudo apt-get update && sudo apt-get install -y build-essential pkgconf libasound2-dev libgl1-mesa-dev libx11-dev
         - script:
             name: gcc-version
             code: gcc --version


### PR DESCRIPTION
Probably not the most beautiful code changes but it works :)

![wayland-screenshot-2018-03-07_01-44-41](https://user-images.githubusercontent.com/208340/37063614-f3601c66-21aa-11e8-938c-106e314b6643.jpg)

- piggybacking on `HOST_OS==OS_LINUX` instead of introducing `OS_FREEBSD`, they're similar enough, so I'm keeping the changes small
- what's with `sys/unistd.h` and other standard headers under `sys/`?! in `audiobackend_oss.cpp`
- `true` is `/usr/bin/true` here — but just `true` is a shell builtin normally, why write `/bin/true`?