### PR TITLE
fix gdi track parsing in unixx

### DIFF
--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -36,9 +36,9 @@ Disc* load_gdi(const char* file)
 	strncpy(path, file, sizeof(path));
 	path[sizeof(path) - 1] = '\0';
 
-	size_t len = strlen(path);
+	ssize_t len = strlen(path);
 
-	while (len>2)
+	while (len>=0)
 	{
 		if (path[len]=='\\' || path[len]=='/')
 			break;


### PR DESCRIPTION
Same problem as https://github.com/libretro/reicast-emulator/pull/24

in unix that iteration would not work if the path of the original .gdi file (where we are finding the 'parent directory') was:

1. not existent, ie a gdi on the same directory as the current. It was iterating until the index 3 and stop there. Disaster strikes later ofc, if the first characters weren't C:\ or other thing like that.
2. in a relative subdirectory that is 'small enough' ie: a/crazy-taxi.gdi. In this case the last '/' wouldn't be found, the derived string would be 'crazy-taxi.gdi' and the file not found ofc.

Anyway, this can be solved simply by searching the whole string and using a signed integer. It will go up to -1, stop iteration and increase to 0 on the len++.

Dunno if using relative subdirectories for the tracks on *other* platforms works because of the path separator being different from what's inside the gdi but with this code fixed it works on linux with / at least.