### PR TITLE
Restore secondary x86_ptr_imm for non-Windows

### DIFF
--- a/core/emitter/x86_emitter.h
+++ b/core/emitter/x86_emitter.h
@@ -229,11 +229,13 @@ struct /*__declspec(dllexport)*/  x86_ptr_imm
 		this->ptr=ptr;
 	}
 
-//	template<typename Rv, typename ...Args>
-//	x86_ptr_imm(Rv(* ptr)(Args...))
-//	{
-//		this->ptr= reinterpret_cast<void*>(ptr);
-//	}
+#ifndef WIN32
+	template<typename Rv, typename ...Args>
+	x86_ptr_imm(Rv(* ptr)(Args...))
+	{
+		this->ptr= reinterpret_cast<void*>(ptr);
+	}
+#endif
 
     template<typename Rv, typename ...Args>
     x86_ptr_imm(Rv(DYNACALL * ptr)(Args...))


### PR DESCRIPTION
This appears to be a necessary duplicate for other platforms.