### PR TITLE
Circumvent PR #1023 on RPI and Vero4K

### DIFF
--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <malloc.h>
 #include "ta.h"
 #include "pvr_regs.h"
 
@@ -151,8 +152,8 @@ struct TA_context
 	}
 	void Alloc()
 	{
-		tad.Reset((u8*)malloc(2*1024*1024));
-
+		tad.Reset((u8*)memalign(32, 2*1024*1024));
+		
 		rend.verts.InitBytes(1024*1024,&rend.Overrun); //up to 1 mb of vtx data/frame = ~ 38k vtx/frame
 		rend.idx.Init(60*1024,&rend.Overrun);			//up to 60K indexes ( idx have stripification overhead )
 		rend.global_param_op.Init(4096,&rend.Overrun);

--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -5,10 +5,10 @@
 #include "pvr_regs.h"
 
 // helper for 32 byte aligned memory allocation
-inline void* aligned_malloc(size_t size, size_t align)
+inline void* aligned_malloc(size_t align, size_t size)
 {
     	void *result;
-    	#ifdef WIN32 
+    	#if HOST_OS == OS_WINDOWS  
     		result = _aligned_malloc(size, align);
     	#else 
      		if(posix_memalign(&result, align, size)) result = 0;


### PR DESCRIPTION
As per Issue #1032 there are seg faults with the changes from PR #1023 (ta: use 256-bit struct).

I confess I don't understand the purpose of the changes, optimisations no doubt, but reverting them still allows building and thankfully does not appear to have broken any subsequent commits.

If there are no objections this commit adds flags to the Makefile to keep the original code for these 2 platforms, so they can be built for Retropie etc.