### PR TITLE
Using native libpng and zlib for Linux build

### DIFF
--- a/core/core.mk
+++ b/core/core.mk
@@ -8,9 +8,12 @@ RZDCY_SRC_DIR ?= $(call my-dir)
 
 RZDCY_MODULES	:=	cfg/ hw/arm7/ hw/aica/ hw/holly/ hw/ hw/gdrom/ hw/maple/ \
  hw/mem/ hw/pvr/ hw/sh4/ hw/sh4/interpr/ hw/sh4/modules/ plugins/ profiler/ oslib/ \
- hw/extdev/ hw/arm/ hw/naomi/ imgread/ linux/ ./ deps/coreio/ deps/zlib/ deps/chdr/ deps/crypto/ \
- deps/libelf/ deps/chdpsr/ arm_emitter/ rend/ reios/ deps/libpng/ 
+ hw/extdev/ hw/arm/ hw/naomi/ imgread/ linux/ ./ deps/coreio/ deps/chdr/ deps/crypto/ \
+ deps/libelf/ deps/chdpsr/ arm_emitter/ rend/ reios/
 
+ifndef FOR_LINUX
+	RZDCY_MODULES += deps/zlib/ deps/libpng/
+endif
 
 ifdef WEBUI
 	RZDCY_MODULES += webui/
@@ -70,7 +73,7 @@ endif
 RZDCY_FILES := $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(wildcard $(dir)*.cpp))
 RZDCY_FILES += $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(wildcard $(dir)*.c))
 RZDCY_FILES += $(foreach dir,$(addprefix $(RZDCY_SRC_DIR)/,$(RZDCY_MODULES)),$(wildcard $(dir)*.S))
-	
+
 ifdef FOR_PANDORA
 RZDCY_CFLAGS	:= \
 	$(CFLAGS) -c -O3 -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps \
@@ -97,6 +100,10 @@ RZDCY_CFLAGS	:= \
       RZDCY_CFLAGS += -DTARGET_LINUX_MIPS
 		endif
 	endif
+endif
+
+ifndef FOR_LINUX
+	RZDCY_CFLAGS += -I$(RZDCY_SRC_DIR)/deps/zlib/ -I$(RZDCY_SRC_DIR)/deps/libpng/
 endif
 
 ifdef NO_REC

--- a/core/deps/chdr/chdr.cpp
+++ b/core/deps/chdr/chdr.cpp
@@ -41,7 +41,7 @@
 
 #include "deps/crypto/md5.h"
 #include "deps/crypto/sha1.h"
-#include "deps/zlib/zlib.h"
+#include <zlib.h>
 
 #include <time.h>
 #include <stddef.h>

--- a/core/hw/maple/maple_devs.cpp
+++ b/core/hw/maple/maple_devs.cpp
@@ -13,7 +13,7 @@
 #define LOGI printf
 #endif
 
-#include "deps/zlib/zlib.h"
+#include <zlib.h>
 
 const char* maple_sega_controller_name = "Dreamcast Controller";
 const char* maple_sega_vmu_name = "Visual Memory";

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -3,7 +3,7 @@
 #include "hw/pvr/pvr_mem.h"
 #include "rend/TexCache.h"
 
-#include "deps/zlib/zlib.h"
+#include <zlib.h>
 
 #include "deps/crypto/md5.h"
 

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -3,6 +3,8 @@
 #include "rend/TexCache.h"
 #include "cfg/cfg.h"
 
+#include <png.h>
+
 #ifdef TARGET_PANDORA
 #include <unistd.h>
 #include <fcntl.h>
@@ -1869,9 +1871,6 @@ struct glesrend : Renderer
 		return gl_GetTexture(tsp, tcw);
 	}
 };
-
-
-#include "deps/libpng/png.h"
 
 FILE* pngfile;
 

--- a/shell/android/jni/src/utils.cpp
+++ b/shell/android/jni/src/utils.cpp
@@ -2,7 +2,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 extern "C" {
-#include "deps/libpng/png.h"
+#include <png.h>
 }
 #include "types.h"
 #include "deps/libzip/zip.h"

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -240,8 +240,8 @@ CXXFLAGS += -fno-rtti -fpermissive -fno-operator-names
 
 INCS += -I$(RZDCY_SRC_DIR) -I$(RZDCY_SRC_DIR)/deps -I$(RZDCY_SRC_DIR)/khronos
 
-LIBS += -lm -lrt -ldl
-LIBS  += -lpthread
+LIBS += -lm -lrt -ldl -lpng -lz
+LIBS += -lpthread
 
 PREFIX ?= /usr/local
 MAN_DIR ?= ${PREFIX}/share/man/man1


### PR DESCRIPTION
Changes to use system _libpng_ and _zlib_ on Linux machines.
Now only tested for Linux (ArchLinux x64, _libpng_: 1.6.34, _zlib_: 1.2.11)

Due to https://developer.android.com/ndk/guides/stable_apis.html, _zlib_ is already present on Android.