### PR TITLE
Enable modifier volumes. Fix for exclusion volumes.

### DIFF
--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -166,7 +166,7 @@ struct TA_context
 		rend.global_param_mvo.Init(4096,&rend.Overrun);
 		rend.global_param_tr.Init(4096,&rend.Overrun);
 
-		rend.modtrig.Init(4096,&rend.Overrun);
+		rend.modtrig.Init(8192,&rend.Overrun);
 		
 		Reset();
 	}

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -243,6 +243,7 @@ void LoadSettings()
     settings.aica.NoSound			= cfgLoadInt("config","aica.NoSound",0);
 	settings.rend.UseMipmaps		= cfgLoadInt("config","rend.UseMipmaps",1);
 	settings.rend.WideScreen		= cfgLoadInt("config","rend.WideScreen",0);
+	settings.rend.ModifierVolumes	= cfgLoadInt("config","rend.ModifierVolumes",1);
 	
 	settings.pvr.subdivide_transp	= cfgLoadInt("config","pvr.Subdivide",0);
 	

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -1109,7 +1109,8 @@ void DrawStrips()
 	/*if (!GetAsyncKeyState(VK_F1))*/
 	DrawList<ListType_Opaque,false>(pvrrc.global_param_op);
 
-	DrawModVols();
+	if (settings.rend.ModifierVolumes)
+		DrawModVols();
 
 	//Alpha tested
 	//setup alpha test state

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -856,6 +856,7 @@ void SetMVS_Mode(u32 mv_mode,ISP_Modvol ispc)
 
 		if (mv_mode==1)
 		{
+			// Inclusion volume
 			//res : old : final 
 			//0   : 0      : 00
 			//0   : 1      : 01
@@ -881,21 +882,22 @@ void SetMVS_Mode(u32 mv_mode,ISP_Modvol ispc)
 		}
 		else
 		{
+			// Exclusion volume
 			/*
-				this is bugged. a lot.
 				I've only seen a single game use it, so i guess it doesn't matter ? (Zombie revenge)
 				(actually, i think there was also another, racing game)
 			*/
 
+			// The initial value for exclusion volumes is 1 so we need to invert the result before and'ing.
 			//res : old : final 
 			//0   : 0   : 00
-			//0   : 1   : 00
+			//0   : 1   : 01
 			//1   : 0   : 00
-			//1   : 1   : 01
+			//1   : 1   : 00
 
-			//if (2>st) st=1; else st=0;	//can't be done with a single pass
-			glStencilFunc(GL_GREATER,1,3);
-			glStencilOp(GL_ZERO,GL_KEEP,GL_REPLACE);
+			//if (1 == st) st = 1; else st = 0;
+			glStencilFunc(GL_EQUAL, 1, 3);
+			glStencilOp(GL_ZERO,GL_KEEP,GL_KEEP);
 #ifndef NO_STENCIL_WORKAROUND
 			//Look @ comment above -- this looks like a driver bug
 			glStencilOp(GL_ZERO,GL_KEEP,GL_REPLACE);
@@ -986,7 +988,7 @@ void DrawModVols()
 		*/
 
 		glColorMask(GL_FALSE,GL_FALSE,GL_FALSE,GL_FALSE);
-		glDepthFunc(GL_GREATER);
+
 		if ( 0 /* || GetAsyncKeyState(VK_F6)*/ )
 		{
 			//simple single level stencil
@@ -1107,7 +1109,7 @@ void DrawStrips()
 	/*if (!GetAsyncKeyState(VK_F1))*/
 	DrawList<ListType_Opaque,false>(pvrrc.global_param_op);
 
-	//DrawModVols();
+	DrawModVols();
 
 	//Alpha tested
 	//setup alpha test state

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -1751,6 +1751,7 @@ bool RenderFrame()
 		glClearColor(0,0,0,1.0f);
 
 	glClearDepthf(0.f); glCheck();
+	glStencilMask(0xFF); glCheck();
 	glClear(GL_COLOR_BUFFER_BIT|GL_STENCIL_BUFFER_BIT|GL_DEPTH_BUFFER_BIT); glCheck();
 
 

--- a/core/types.h
+++ b/core/types.h
@@ -615,6 +615,7 @@ struct settings_t
 	{
 		bool UseMipmaps;
 		bool WideScreen;
+		bool ModifierVolumes;
 	} rend;
 
 	struct


### PR DESCRIPTION
Increased the number of modifier triangles to prevent overruns with some games (Jet Grind Radio).
Reset the stencil mask before clearing as some drivers use it when clearing (Raspberry Pi).
Exclusion volumes tested with Zombie Revenge.