### PR TITLE
Fix video choppiness

### DIFF
--- a/core/hw/pvr/pvr_regs.cpp
+++ b/core/hw/pvr/pvr_regs.cpp
@@ -72,7 +72,11 @@ void pvr_WriteReg(u32 paddr,u32 data)
 	}
 
 	if (addr == TA_YUV_TEX_BASE_addr)
+	{
+		PvrReg(addr, u32) = data;
 		YUV_init();
+		return;
+	}
 
 	if (addr>=PALETTE_RAM_START_addr)
 	{


### PR DESCRIPTION
The YUV texture address was being initialized with the previous value instead of the current one.