### PR TITLE
Add a not-so simple template for issues

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,18 +1,29 @@
-Please include the following information before submitting your issue
 Any information not included may be requested when diagnosing the issue
 
-Description of the Issue
-------------------------
+| Branch | Hash | Buildbot |
+| ------ | ---- | -------- |
+| Branch name (or Google Play) | hashtag (delete if unknown) | Downloaded from buildbot? |
+
+**_Description of the Issue_**
+
+Add a short, concise description of the issue
+
+**_Debugging Steps Tested_**
+
+  * Fill in any steps already tried
+  * Begin each line with an asterisk
+
+**_Logs Gathered_**
+
+```
+
+Paste the contents of the log / logs here
+
+```
 
 
-Version (Google Play, Branch Name)
----------------------------------
+**_Screenshots_**
 
+![Issue Screenshot](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png)
 
-Debugging Steps Tested
-----------------------
-
-
-Logs & Screenshots Gathered
----------------------------
-
+- [ ] Check this box to confirm you have filled in all relevant information

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,4 +1,4 @@
-Any information not included may be requested when diagnosing the issue
+*Any information not included may be requested when diagnosing the issue*
 
 | Branch | Hash | Buildbot |
 | ------ | ---- | -------- |

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,18 @@
+Please include the following information before submitting your issue
+Any information not included may be requested when diagnosing the issue
+
+Description of the Issue
+------------------------
+
+
+Version (Google Play, Branch Name)
+---------------------------------
+
+
+Debugging Steps Tested
+----------------------
+
+
+Logs & Screenshots Gathered
+---------------------------
+


### PR DESCRIPTION
This creates a "form" that will automatically populate when submitting new issues.

There are various options for how this is handled, including per-branch templates

https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/