### PR TITLE
X11: Refactored and fixed buttons

### DIFF
--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -77,12 +77,12 @@ void input_x11_handle()
 			{
 				case KeyPress:
 				case KeyRelease:
-					if (e.type == KeyRelease && e.xkey.keycode == 9) // ESC button
+					if (e.type == KeyRelease && e.xkey.keycode == KEY_ESC)
 					{
-						die("death by escape key");
+						die("X11: death by escape key");
 					}
 #if FEAT_HAS_NIXPROF
-					else if (e.type == KeyRelease && e.xkey.keycode == 76) // F10 button
+					else if (e.type == KeyRelease && e.xkey.keycode == KEY_F10)
 					{
 						if (sample_Switch(3000)) {
 							printf("Starting profiling\n");
@@ -91,7 +91,7 @@ void input_x11_handle()
 						}
 					}
 #endif
-					else if (e.type == KeyRelease && e.xkey.keycode == 95) // F11 button
+					else if (e.type == KeyRelease && e.xkey.keycode == KEY_F11)
 					{
 						x11_fullscreen = !x11_fullscreen;
 						x11_window_set_fullscreen(x11_fullscreen);
@@ -99,6 +99,24 @@ void input_x11_handle()
 					else
 					{
 						int dc_key = x11_keymap[e.xkey.keycode];
+
+						if (e.xkey.keycode == KEY_F)
+						{
+							// Left shoulder button pressed (lt)
+							if (e.type == KeyPress)
+								lt[0] = 255;
+							else
+								lt[0] = 0;
+						}
+						else if (e.xkey.keycode == KEY_V)
+						{
+							// Right shoulder button pressed (rt)
+							if (e.type == KeyPress)
+								rt[0] = 255;
+							else
+								rt[0] = 0;
+						}
+
 						if (e.type == KeyPress)
 						{
 							kcode[0] &= ~dc_key;
@@ -107,8 +125,9 @@ void input_x11_handle()
 						{
 							kcode[0] |= dc_key;
 						}
+
+						printf("KEY: %d -> %d: %d\n", e.xkey.keycode, dc_key, x11_dc_buttons );
 					}
-					//printf("KEY: %d -> %d: %d\n",e.xkey.keycode, dc_key, x11_dc_buttons );
 					break;
 			}
 		}
@@ -117,23 +136,34 @@ void input_x11_handle()
 
 void input_x11_init()
 {
-	x11_keymap[113] = DC_DPAD_LEFT;
-	x11_keymap[114] = DC_DPAD_RIGHT;
+	x11_keymap[KEY_LEFT] = DC_DPAD_LEFT;
+	x11_keymap[KEY_RIGHT] = DC_DPAD_RIGHT;
 
-	x11_keymap[111] = DC_DPAD_UP;
-	x11_keymap[116] = DC_DPAD_DOWN;
+	x11_keymap[KEY_UP] = DC_DPAD_UP;
+	x11_keymap[KEY_DOWN] = DC_DPAD_DOWN;
 
-	x11_keymap[53] = DC_BTN_X;
-	x11_keymap[54] = DC_BTN_B;
-	x11_keymap[55] = DC_BTN_A;
+	// Layout on a real DC controller
+	//   Y
+	// X   B
+	//   A
+	x11_keymap[KEY_S] = DC_BTN_X;
+	x11_keymap[KEY_X] = DC_BTN_A;
+	x11_keymap[KEY_D] = DC_BTN_Y;
+	x11_keymap[KEY_C] = DC_BTN_B;
+
+	// ???
+	x11_keymap[KEY_Q] = DC_BTN_Z;
+	x11_keymap[KEY_W] = DC_BTN_C;
+	x11_keymap[KEY_E] = DC_BTN_D;
+
+	// Start button (triangle)
+	x11_keymap[KEY_RETURN] = DC_BTN_START;
 
 	/*
 	//TODO: Fix sliders
-	x11_keymap[38] = DPad_Down;
-	x11_keymap[39] = DPad_Down;
+	x11_keymap[KEY_A] = DPad_Down;
+	x11_keymap[KEY_S] = DPad_Down;
 	*/
-
-	x11_keymap[36] = DC_BTN_START;
 
 	x11_keyboard_input = cfgLoadInt("input", "enable_x11_keyboard", 1);
 }

--- a/core/linux-dist/x11.h
+++ b/core/linux-dist/x11.h
@@ -5,3 +5,71 @@ extern void input_x11_init();
 extern void input_x11_handle();
 extern void x11_window_create();
 extern void x11_window_set_text(const char* text);
+
+// numbers
+const int KEY_1		=  10;
+const int KEY_2		=  11;
+const int KEY_3		=  12;
+const int KEY_4		=  13;
+const int KEY_5		=  14;
+const int KEY_6		=  15;
+const int KEY_7		=  16;
+const int KEY_8		=  17;
+const int KEY_9		=  18;
+const int KEY_0		=  19;
+
+// characters
+const int KEY_A		=  38;
+const int KEY_B		=  56;
+const int KEY_C		=  54;
+const int KEY_D		=  40;
+const int KEY_E		=  26;
+const int KEY_F		=  41;
+const int KEY_G		=  42;
+const int KEY_H		=  43;
+const int KEY_I		=  31;
+const int KEY_J		=  44;
+const int KEY_K		=  45;
+const int KEY_L		=  46;
+const int KEY_M		=  58;
+const int KEY_N		=  57;
+const int KEY_O		=  32;
+const int KEY_P		=  33;
+const int KEY_Q		=  24;
+const int KEY_R		=  27;
+const int KEY_S		=  39;
+const int KEY_T		=  28;
+const int KEY_U		=  30;
+const int KEY_V		=  55;
+const int KEY_W		=  25;
+const int KEY_X		=  53;
+const int KEY_Y		=  52;
+const int KEY_Z		=  29;
+
+// special
+const int KEY_ESC	=   9;
+const int KEY_TAB	=  23;
+const int KEY_RETURN	=  36;
+const int KEY_HOME	= 110;
+const int KEY_UP	= 111;
+const int KEY_PGUP	= 112;
+const int KEY_LEFT	= 113;
+const int KEY_RIGHT	= 114;
+const int KEY_END	= 115;
+const int KEY_DOWN	= 116;
+const int KEY_PGDOWN	= 117;
+const int KEY_INS	= 118;
+const int KEY_DEL	= 118;
+
+const int KEY_F1	=  67;
+const int KEY_F2	=  68;
+const int KEY_F3	=  69;
+const int KEY_F4	=  70;
+const int KEY_F5	=  71;
+const int KEY_F6	=  72;
+const int KEY_F7	=  73;
+const int KEY_F8	=  74;
+const int KEY_F9	=  75;
+const int KEY_F10	=  76;
+const int KEY_F11	=  95;
+const int KEY_F12	=  96;


### PR DESCRIPTION
Some keys were not mapped like left and right shoulder buttons which I mapped to "F" and "V".
I also added constants for the X11 keys (f. e. "KEY_ESC") and used those instead of magic number ("9").
Also to avoid confusion I added "X11: " before some messages to know if this came from the X11 or another backend.