### PR TITLE
evdev: Allow for custom <device>.cfg files in the /mappings/ directory.

### DIFF
--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -261,6 +261,7 @@ string get_writable_config_path(const string& filename);
 string get_writable_data_path(const string& filename);
 string get_readonly_config_path(const string& filename);
 string get_readonly_data_path(const string& filename);
+bool file_exists(const string& filename);
 
 
 class VArray2


### PR DESCRIPTION
Check if a configuration file named exactly like the device exists in the /mappings/ directory.
If it does, use this instead of the generic one.

Exposes ``file_exists()`` from stdclass.