### PR TITLE
[c++11] core: adding high resolution clock

### DIFF
--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -18,7 +18,6 @@
 #include "hw/aica/aica_if.h"
 #include "hw/gdrom/gdrom_if.h"
 
-#include <time.h>
 #include <float.h>
 
 #include "blockmanager.h"

--- a/core/hw/sh4/interpr/sh4_interpreter.cpp
+++ b/core/hw/sh4/interpr/sh4_interpreter.cpp
@@ -22,7 +22,6 @@
 #include "../dyna/blockmanager.h"
 #include "../sh4_sched.h"
 
-#include <time.h>
 #include <float.h>
 
 #define SH4_TIMESLICE (448)

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -17,7 +17,6 @@
 #include <signal.h>
 #include <sys/param.h>
 #include <sys/mman.h>
-#include <sys/time.h>
 #if !defined(_ANDROID) && !defined(TARGET_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_OSX)
   #include <sys/personality.h>
   #include <dlfcn.h>
@@ -254,13 +253,6 @@ void VArray2::UnLockRegion(u32 offset,u32 size)
 	#else
 		printf("VA2: UnLockRegion\n");
 	#endif
-}
-double os_GetSeconds()
-{
-	timeval a;
-	gettimeofday (&a,0);
-	static u64 tvs_base=a.tv_sec;
-	return a.tv_sec-tvs_base+a.tv_usec/1000000.0;
 }
 
 #if TARGET_IPHONE

--- a/core/oslib/oslib.h
+++ b/core/oslib/oslib.h
@@ -3,7 +3,6 @@
 
 void os_SetWindowText(const char* text);
 void os_MakeExecutable(void* ptr, u32 sz);
-double os_GetSeconds();
 
 void os_DoEvents();
 void os_CreateWindow();

--- a/core/stdclass.cpp
+++ b/core/stdclass.cpp
@@ -1,7 +1,9 @@
 #include <string.h>
-#include <vector>
 #include <sys/stat.h>
 #include "types.h"
+
+#include <chrono>
+#include <vector>
 
 #if BUILD_COMPILER==COMPILER_VC
 	#include <io.h>
@@ -101,6 +103,15 @@ string get_readonly_data_path(const string& filename)
 	return user_filepath;
 }
 
+double os_GetSeconds()
+{
+    static auto time_base = std::chrono::high_resolution_clock::now();
+
+    auto time_now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = time_now - time_base;
+
+    return diff.count();
+}
 
 #if 0
 //File Enumeration

--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -297,6 +297,7 @@ public:
 int ExeptionHandler(u32 dwCode, void* pExceptionPointers);
 int msgboxf(const wchar* text,unsigned int type,...);
 
+extern double os_GetSeconds();
 
 #define MBX_OK                       0x00000000L
 #define MBX_OKCANCEL                 0x00000001L

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -705,20 +705,7 @@ int CALLBACK WinMain(HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine
 	return 0;
 }
 
-
-	
-LARGE_INTEGER qpf;
-double  qpfd;
 //Helper functions
-double os_GetSeconds()
-{
-	static bool initme = (QueryPerformanceFrequency(&qpf), qpfd=1/(double)qpf.QuadPart);
-	LARGE_INTEGER time_now;
-
-	QueryPerformanceCounter(&time_now);
-	return time_now.QuadPart*qpfd;
-}
-
 void os_DebugBreak()
 {
 	__debugbreak();


### PR DESCRIPTION
Changing _os_GetSeconds_ code to platform agnostic, enabling high resolution clock.
Also removed redundant includes.