### PR TITLE
GDI: Initialize variables and reset "skip whitespace"-flag

### DIFF
--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -126,7 +126,7 @@ Disc* load_gdi(const char* file)
 			track_filename = last + track_filename;
 		}
 
-		gdi >> OFFSET;
+		gdi >> std::skipws >> OFFSET;
 		
 		printf("file[%d] \"%s\": FAD:%d, CTRL:%d, SSIZE:%d, OFFSET:%d\n", TRACK, track_filename.c_str(), FADS, CTRL, SSIZE, OFFSET);
 

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -93,11 +93,11 @@ Disc* load_gdi(const char* file)
 	
 	string basepath = OS_dirname(file);
 
-	u32 TRACK=0,FADS=0,CTRL=0,SSIZE=0;
-	s32 OFFSET=0;
 	for (u32 i=0;i<iso_tc;i++)
 	{
-		string track_filename;
+		string track_filename = {};
+		u32 TRACK=0,FADS=0,CTRL=0,SSIZE=0;
+		s32 OFFSET=0;
 
 		//TRACK FADS CTRL SSIZE file OFFSET
 		gdi >> TRACK;

--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -105,7 +105,7 @@ Disc* load_gdi(const char* file)
 		gdi >> CTRL;
 		gdi >> SSIZE;
 
-		char last;
+		char last = {};
 
 		do {
 			gdi >> last;


### PR DESCRIPTION
When loading gdi files with special characters, the variables are not reset. That way it was a little hard to know what was wrong, so I now initialize them per track.

In the following GDI example reading the third line (``2 450...``) the variable ``last`` still contains the ``"`` from the previous line.
````
3
1 0 4 2352 "track (0,1).bin" 0
2 450 0 2352 track02.raw 0
3 45000 4 2352 track03.bin 0
````

What was the main problem here is that for reading special filenames the flag ``std::noskipws`` is set but never reset. That way in the next line the ``TRACK``, ``FADS``, etc. were never set.
That was the output I got:
````
GDI : 3 tracks
file[1] "track (0,1).bin": FAD:0, CTRL:4, SSIZE:2352, OFFSET:0
file[0] "": FAD:0, CTRL:0, SSIZE:0, OFFSET:0
file[0] "": FAD:0, CTRL:0, SSIZE:0, OFFSET:0
````

After my changes this is the output:
````
GDI : 3 tracks
file[1] "track (0,1).bin": FAD:0, CTRL:4, SSIZE:2352, OFFSET:0
file[2] "track02.raw": FAD:450, CTRL:0, SSIZE:2352, OFFSET:0
file[3] "track03.bin": FAD:45000, CTRL:4, SSIZE:2352, OFFSET:0
````
This fixes #1006.