### PR TITLE
LGTM: Fix "Function input_evdev_handle should return a value of type bool but does not return a value here"

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -321,12 +321,12 @@
 		}
 	}
 
-	bool input_evdev_handle(EvdevController* controller, u32 port)
+	void input_evdev_handle(EvdevController* controller, u32 port)
 	{
 		#define SET_FLAG(field, mask, expr) field =((expr) ? (field & ~mask) : (field | mask))
 		if (controller->fd < 0 || controller->mapping == NULL)
 		{
-			return false;
+			return;
 		}
 
 		input_event ie;

--- a/core/linux-dist/evdev.h
+++ b/core/linux-dist/evdev.h
@@ -72,5 +72,5 @@ struct EvdevController
 #define EVDEV_DEFAULT_DEVICE_ID(port) (port == 1 ? EVDEV_DEFAULT_DEVICE_ID_1 : -1)
 
 extern int input_evdev_init(EvdevController* controller, const char* device, const char* mapping_fname);
-extern bool input_evdev_handle(EvdevController* controller, u32 port);
+extern void input_evdev_handle(EvdevController* controller, u32 port);
 extern void input_evdev_rumble(EvdevController* controller, u16 pow_strong, u16 pow_weak);


### PR DESCRIPTION
The return value of input_evdev_handle() was never used, so just return void.

This fixes one of the lgtm warnings (see #1117).