### PR TITLE
Fix controller support for Linux when building with GCC8

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -468,6 +468,7 @@
 					break;
 			}
 		}
+		return true;
 	}
 
 	void input_evdev_rumble(EvdevController* controller, u16 pow_strong, u16 pow_weak)


### PR DESCRIPTION
On Linux the window stays black without any error message when a joystick/controller is connected and reicast was build with GCC8. This is probably due to changes made in GCC8. https://gcc.gnu.org/gcc-8/porting_to.html#Wreturn-type