### PR TITLE
GL3: Use log2 depth scaling in fragment shader

### DIFF
--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -100,10 +100,21 @@ void main() \n\
 	vec4 vpos=in_pos; \n\
 	vtx_xyz.xy = vpos.xy;  \n\
 	vtx_xyz.z = vpos.z*sp_FOG_DENSITY;  \n\
-	vpos.w=1.0/vpos.z;  \n\
+	vpos.w=1.0/vpos.z;  \n"
+#ifndef GLES
+	"\
+	if (vpos.w < 0.0) { \n\
+		gl_Position = vec4(0.0, 0.0, 0.0, vpos.w); \n\
+		return; \n\
+	} \n\
+	vpos.z = vpos.w; \n"
+#else
+	"\
+	vpos.z=depth_scale.x+depth_scale.y*vpos.w;  \n"
+#endif
+	"\
 	vpos.xy=vpos.xy*scale.xy-scale.zw;  \n\
 	vpos.xy*=vpos.w;  \n\
-	vpos.z=depth_scale.x+depth_scale.y*vpos.w;  \n\
 	gl_Position = vpos; \n\
 }";
 
@@ -327,8 +338,13 @@ void main() \n\
 	#if cp_AlphaTest == 1 \n\
 		if (cp_AlphaTestValue>color.a) discard;\n\
 	#endif  \n\
-	//color.rgb=vec3(vtx_xyz.z/255.0);\n\
-	" FRAGCOL "=color; \n\
+	//color.rgb=vec3(vtx_xyz.z/255.0);\n"
+#ifndef GLES
+	"\
+	highp float w = gl_FragCoord.w * 100000.0; \n\
+	gl_FragDepth = log2(1.0 + w) / 34.0; \n"
+#endif
+	FRAGCOL "=color; \n\
 }";
 
 const char* ModifierVolumeShader =
@@ -340,8 +356,13 @@ const char* ModifierVolumeShader =
 uniform lowp float sp_ShaderColor; \n\
 /* Vertex input*/ \n\
 void main() \n\
-{ \n\
-	" FRAGCOL "=vec4(0.0, 0.0, 0.0, sp_ShaderColor); \n\
+{ \n"
+#ifndef GLES
+	"\
+	highp float w = gl_FragCoord.w * 100000.0; \n\
+	gl_FragDepth = log2(1.0 + w) / 34.0; \n"
+#endif
+	FRAGCOL "=vec4(0.0, 0.0, 0.0, sp_ShaderColor); \n\
 }";
 
 const char* OSD_Shader =


### PR DESCRIPTION
Currently a compile time option (!GLES). Fixes many depth issues (Dynamite Cop, Cannon Spike, etc.)