### PR TITLE
evdev: Allow two controls with the same event

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -158,8 +158,11 @@
 		ConfigFile mf;
 		mf.parse(fd);
 
+		string name = mf.get("emulator", "mapping_name", "<Unknown>");
+		char * cstr = new char[name.length()+1];
+  		strcpy (cstr, name.c_str());
 		EvdevControllerMapping mapping = {
-			mf.get("emulator", "mapping_name", "<Unknown>").c_str(),
+			cstr,
 			load_keycode(&mf, "dreamcast", "btn_a"),
 			load_keycode(&mf, "dreamcast", "btn_b"),
 			load_keycode(&mf, "dreamcast", "btn_c"),
@@ -192,6 +195,7 @@
 			mf.get_bool("compat", "axis_trigger_left_inverted", false),
 			mf.get_bool("compat", "axis_trigger_right_inverted", false)
 		};
+
 		return mapping;
 	}
 

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -127,14 +127,6 @@ void SetupInput()
 			}
 			else
 			{
-				for (i = 0; i < port; i++)
-				{
-						if (evdev_device_id[port] == evdev_device_id[i])
-						{
-								die("You can't assign the same device to multiple ports!\n");
-						}
-				}
-
 				size_needed = snprintf(NULL, 0, EVDEV_DEVICE_STRING, evdev_device_id[port]) + 1;
 				evdev_device = (char*)malloc(size_needed);
 				sprintf(evdev_device, EVDEV_DEVICE_STRING, evdev_device_id[port]);


### PR DESCRIPTION
My testing showed, that the check about the same event used in multiple configurations is no problem at all (tested with CAPCOM vs. SNK - Millennium Fight 2000 (PAL)).

Also the name of the configuration file was not copied correctly into the EvdevControllerMapping resulting in output like ``evdev: Using '}��U' mapping`` (instead of ``evdev: Using 'Logitech Logitech RumblePad 2 USB' mapping``).
Does my fix produce a memory leak? If so, where to free that?

Fixes #1042.