### PR TITLE
Update AEG params when FNS or OCT registers are updated

### DIFF
--- a/core/hw/aica/sgc_if.cpp
+++ b/core/hw/aica/sgc_if.cpp
@@ -688,6 +688,7 @@ struct ChannelEx
 		case 0x18://FNS
 		case 0x19://FNS,OCT
 			UpdatePitch();
+			UpdateAEG();
 			break;
 
 		case 0x1C://ALFOS,ALFOWS,PLFOS


### PR DESCRIPTION
Fixes Bomberman Online FMV intro freeze, Jet Grind Radio and Psyvariar 2 intro music fade out and probably more.

