### PR TITLE
Android: restore hard exiting thread (w/ notes)

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNINative.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNINative.java
@@ -587,11 +587,6 @@ public class GL2JNINative extends NativeActivity {
 	}
 
 	@Override
-	protected void onStop() {
-		super.onStop();
-	}
-
-	@Override
 	public void onConfigurationChanged(Configuration newConfig) {
 		super.onConfigurationChanged(newConfig);
 	}

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/GL2JNIView.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/GL2JNIView.java
@@ -681,6 +681,8 @@ public class GL2JNIView extends GLSurfaceView
     }
 
     public void onDestroy() {
+        // Workaround for ANR when returning to menu
+        System.exit(0);
         try {
             ethd.join();
         } catch (InterruptedException e) {


### PR DESCRIPTION
This is not yet avoidable, but can at least be explained.