### PR TITLE
Android: Fix the misleading "default disk" setting

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
@@ -25,7 +25,7 @@ public class Emulator extends Application {
     public static final String pref_pvrrender = "pvr_render";
     public static final String pref_syncedrender = "synced_render";
     public static final String pref_modvols = "modifier_volumes";
-    public static final String pref_cheatdisk = "cheat_disk";
+    public static final String pref_bootdisk = "boot_disk";
     public static final String pref_usereios = "use_reios";
 
     public static boolean dynarecopt = true;
@@ -44,7 +44,7 @@ public class Emulator extends Application {
     public static boolean pvrrender = false;
     public static boolean syncedrender = false;
     public static boolean modvols = true;
-    public static String cheatdisk = "null";
+    public static String bootdisk = "null";
     public static boolean usereios = false;
     public static boolean nativeact = false;
     
@@ -66,7 +66,7 @@ public class Emulator extends Application {
         Emulator.pvrrender = mPrefs.getBoolean(pref_pvrrender, pvrrender);
         Emulator.syncedrender = mPrefs.getBoolean(pref_syncedrender, syncedrender);
         Emulator.modvols = mPrefs.getBoolean(pref_modvols, modvols);
-        Emulator.cheatdisk = mPrefs.getString(pref_cheatdisk, cheatdisk);
+        Emulator.bootdisk = mPrefs.getString(pref_bootdisk, bootdisk);
         Emulator.usereios = mPrefs.getBoolean(pref_usereios, usereios);
         Emulator.nativeact = mPrefs.getBoolean(pref_nativeact, nativeact);
     }
@@ -93,7 +93,7 @@ public class Emulator extends Application {
         JNIdc.syncedrender(Emulator.syncedrender ? 1 : 0);
         JNIdc.modvols(Emulator.modvols ? 1 : 0);
         JNIdc.usereios(Emulator.usereios ? 1 : 0);
-        JNIdc.cheatdisk(Emulator.cheatdisk);
+        JNIdc.bootdisk(Emulator.bootdisk);
         JNIdc.dreamtime(DreamTime.getDreamtime());
     }
 

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
@@ -480,27 +480,27 @@ public class OptionsFragment extends Fragment {
 		modifier_volumes.setChecked(Emulator.modvols);
 		modifier_volumes.setOnCheckedChangeListener(mod_volumes);
 
-		final EditText cheatEdit = (EditText) getView().findViewById(R.id.cheat_disk);
-		String disk = Emulator.cheatdisk;
+		final EditText bootdiskEdit = (EditText) getView().findViewById(R.id.boot_disk);
+		String disk = Emulator.bootdisk;
 		if (disk != null && disk.contains("/")) {
-			cheatEdit.setText(disk.substring(disk.lastIndexOf("/"),
+			bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
 					disk.length()));
 		} else {
-			cheatEdit.setText(disk);
+			bootdiskEdit.setText(disk);
 		}
 
-		cheatEdit.addTextChangedListener(new TextWatcher() {
+		bootdiskEdit.addTextChangedListener(new TextWatcher() {
 			public void afterTextChanged(Editable s) {
-				if (cheatEdit.getText() != null) {
-					String disk = cheatEdit.getText().toString();
+				if (bootdiskEdit.getText() != null) {
+					String disk = bootdiskEdit.getText().toString();
 					if (disk.contains("/")) {
-						cheatEdit.setText(disk.substring(disk.lastIndexOf("/"),
+						bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
 								disk.length()));
 					} else {
-						cheatEdit.setText(disk);
+						bootdiskEdit.setText(disk);
 					}
-					mPrefs.edit().putString(Emulator.pref_cheatdisk, disk).apply();
-					Emulator.cheatdisk = disk;
+					mPrefs.edit().putString(Emulator.pref_bootdisk, disk).apply();
+					Emulator.bootdisk = disk;
 				}
 			}
 
@@ -721,7 +721,7 @@ public class OptionsFragment extends Fragment {
 		mPrefs.edit().remove(Emulator.pref_pvrrender).apply();
 		mPrefs.edit().remove(Emulator.pref_syncedrender).apply();
 		mPrefs.edit().remove(Emulator.pref_modvols).apply();
-		mPrefs.edit().remove(Emulator.pref_cheatdisk).apply();
+		mPrefs.edit().remove(Emulator.pref_bootdisk).apply();
 		mPrefs.edit().remove(Config.pref_showfps).apply();
 		mPrefs.edit().remove(Config.pref_rendertype).apply();
 		mPrefs.edit().remove(Emulator.pref_nosound).apply();

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
@@ -44,7 +44,7 @@ public final class JNIdc
 	public static native void pvrrender(int render);
 	public static native void syncedrender(int sync);
 	public static native void modvols(int volumes);
-	public static native void cheatdisk(String disk);
+	public static native void bootdisk(String disk);
 	public static native void usereios(int reios);
 	public static native void dreamtime(long clock);
 

--- a/shell/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -61,7 +61,7 @@ extern "C"
     JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_pvrrender(JNIEnv *env,jobject obj, jint render)  __attribute__((visibility("default")));
     JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_syncedrender(JNIEnv *env,jobject obj, jint sync)  __attribute__((visibility("default")));
     JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_modvols(JNIEnv *env,jobject obj, jint volumes)  __attribute__((visibility("default")));
-    JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_cheatdisk(JNIEnv *env,jobject obj, jstring disk)  __attribute__((visibility("default")));
+    JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_bootdisk(JNIEnv *env,jobject obj, jstring disk)  __attribute__((visibility("default")));
     JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_usereios(JNIEnv *env,jobject obj, jint reios)  __attribute__((visibility("default")));
     JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_dreamtime(JNIEnv *env,jobject obj, jlong clock)  __attribute__((visibility("default")));
 };
@@ -146,7 +146,7 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_modvols(JNIEnv *env,j
     settings.rend.ModifierVolumes = volumes;
 }
 
-JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_cheatdisk(JNIEnv *env,jobject obj, jstring disk)
+JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_bootdisk(JNIEnv *env,jobject obj, jstring disk)
 {
 
 }

--- a/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
@@ -754,11 +754,11 @@
                 android:orientation="vertical" >
 
                 <TextView
-                    android:id="@+id/cheatdisk_text"
+                    android:id="@+id/boot_disk_text"
                     android:layout_width="wrap_content"
                     android:layout_height="0dip"
                     android:layout_weight="1"
-                    android:text="@string/default_disk" />
+                    android:text="@string/boot_disk" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -766,7 +766,7 @@
                     android:orientation="vertical" >
 
                     <EditText
-                        android:id="@+id/cheat_disk"
+                        android:id="@+id/boot_disk"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"

--- a/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
@@ -754,11 +754,11 @@
                 android:orientation="vertical" >
 
                 <TextView
-                    android:id="@+id/cheatdisk_text"
+                    android:id="@+id/boot_disk_text"
                     android:layout_width="wrap_content"
                     android:layout_height="0dip"
                     android:layout_weight="1"
-                    android:text="@string/default_disk" />
+                    android:text="@string/boot_disk" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -766,7 +766,7 @@
                     android:orientation="vertical" >
 
                     <EditText
-                        android:id="@+id/cheat_disk"
+                        android:id="@+id/boot_disk"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"

--- a/shell/android-studio/reicast/src/main/res/values/strings.xml
+++ b/shell/android-studio/reicast/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
     <string name="select_software">Force Software Rendering</string>
     <string name="select_sound">Disable Emulator Sound</string>
     <string name="select_depth">Rendering Depth</string>
-    <string name="default_disk">Default Disk</string>
+    <string name="boot_disk">Boot Disk (ie. Gameshark, Utopia)</string>
 
     <string name="reset_emu">Reset Emu</string>
     <string name="reset_emu_title">Reset Emulator Settings</string>
@@ -133,10 +133,6 @@
     <string name="downloadVMU">Download VMU</string>
     
     <string name="log_saved">Logcat saved and copied to clipboard\nPlease paste inside the Github issue</string>
-
-    <string name="service_ticker">reicast is running...</string>
-    <string name="service_title">reicast is running...</string>
-    <string name="service_content">Emulator service is currently running</string>
     
     <!-- Onscreen Menu -->
     <string name="popup_button_back">Back</string>


### PR DESCRIPTION
It is a boot disk, which would be the "default" disk. Labeling it default is misleading, though. It will also prevent confusion to have examples of common boot disks.