### PR TITLE
evdev: Check for duplicate key assignment

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -196,6 +196,52 @@
 		};
 		return mapping;
 	}
+	
+	bool input_evdev_button_assigned(EvdevControllerMapping* mapping, int button)
+	{
+		return ((mapping->Btn_A == button) 
+			|| (mapping->Btn_B == button) 
+			|| (mapping->Btn_C == button) 
+			|| (mapping->Btn_D == button) 
+			|| (mapping->Btn_X == button) 
+			|| (mapping->Btn_Y == button) 
+			|| (mapping->Btn_Z == button) 
+			|| (mapping->Btn_Start == button) 
+			|| (mapping->Btn_Escape == button) 
+			|| (mapping->Btn_DPad_Left == button) 
+			|| (mapping->Btn_DPad_Right == button) 
+			|| (mapping->Btn_DPad_Up == button) 
+			|| (mapping->Btn_DPad_Down == button) 
+			|| (mapping->Btn_DPad2_Left == button) 
+			|| (mapping->Btn_DPad2_Right == button) 
+			|| (mapping->Btn_DPad2_Up == button) 
+			|| (mapping->Btn_DPad2_Down == button) 
+			|| (mapping->Btn_Trigger_Left == button) 
+			|| (mapping->Btn_Trigger_Right == button));
+	}
+	
+	bool input_evdev_button_duplicate_button(EvdevControllerMapping* mapping1, EvdevControllerMapping* mapping2)
+	{
+		return (input_evdev_button_assigned(mapping1, mapping2->Btn_A)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_B)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_C)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_D)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_X)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Y)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Z)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Start)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Escape)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad_Left)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad_Right)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad_Up)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad_Down)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad2_Left)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad2_Right)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad2_Up)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_DPad2_Down)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Trigger_Left)
+			|| input_evdev_button_assigned(mapping1, mapping2->Btn_Trigger_Right));
+	}
 
 	int input_evdev_init(EvdevController* controller, const char* device, const char* custom_mapping_fname = NULL)
 	{

--- a/core/linux-dist/evdev.h
+++ b/core/linux-dist/evdev.h
@@ -74,3 +74,4 @@ struct EvdevController
 extern int input_evdev_init(EvdevController* controller, const char* device, const char* mapping_fname);
 extern bool input_evdev_handle(EvdevController* controller, u32 port);
 extern void input_evdev_rumble(EvdevController* controller, u16 pow_strong, u16 pow_weak);
+extern bool input_evdev_button_duplicate_button(EvdevControllerMapping* mapping1, EvdevControllerMapping* mapping2);

--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -142,6 +142,18 @@ void SetupInput()
 				input_evdev_init(&evdev_controllers[port], evdev_device, mapping);
 
 				free(evdev_device);
+
+				for (i = 0; i < port; i++)
+				{
+						if (evdev_device_id[port] == evdev_device_id[i])
+						{
+							// Multiple controllers with the same device, check for multiple button assignments
+							if (input_evdev_button_duplicate_button(evdev_controllers[i].mapping, evdev_controllers[port].mapping))
+							{
+								printf("WARNING: One or more button(s) of this device is also used in the configuration of input device %d (mapping: %s)\n", i, evdev_controllers[i].mapping->name);
+							}
+						}
+				}
 			}
 		}
 	#endif


### PR DESCRIPTION
If a device is configured more than once that can be intentional, however assigning the same button for multiple players may not.
So print a warning in that case.

Follow up of #1273.