### PR TITLE
Android: Disable the boot disk option until valid

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
@@ -480,36 +480,36 @@ public class OptionsFragment extends Fragment {
 		modifier_volumes.setChecked(Emulator.modvols);
 		modifier_volumes.setOnCheckedChangeListener(mod_volumes);
 
-		final EditText bootdiskEdit = (EditText) getView().findViewById(R.id.boot_disk);
-		String disk = Emulator.bootdisk;
-		if (disk != null && disk.contains("/")) {
-			bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
-					disk.length()));
-		} else {
-			bootdiskEdit.setText(disk);
-		}
-
-		bootdiskEdit.addTextChangedListener(new TextWatcher() {
-			public void afterTextChanged(Editable s) {
-				if (bootdiskEdit.getText() != null) {
-					String disk = bootdiskEdit.getText().toString();
-					if (disk.contains("/")) {
-						bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
-								disk.length()));
-					} else {
-						bootdiskEdit.setText(disk);
-					}
-					mPrefs.edit().putString(Emulator.pref_bootdisk, disk).apply();
-					Emulator.bootdisk = disk;
-				}
-			}
-
-			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-			}
-
-			public void onTextChanged(CharSequence s, int start, int before, int count) {
-			}
-		});
+//		final EditText bootdiskEdit = (EditText) getView().findViewById(R.id.boot_disk);
+//		String disk = Emulator.bootdisk;
+//		if (disk != null && disk.contains("/")) {
+//			bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
+//					disk.length()));
+//		} else {
+//			bootdiskEdit.setText(disk);
+//		}
+//
+//		bootdiskEdit.addTextChangedListener(new TextWatcher() {
+//			public void afterTextChanged(Editable s) {
+//				if (bootdiskEdit.getText() != null) {
+//					String disk = bootdiskEdit.getText().toString();
+//					if (disk.contains("/")) {
+//						bootdiskEdit.setText(disk.substring(disk.lastIndexOf("/"),
+//								disk.length()));
+//					} else {
+//						bootdiskEdit.setText(disk);
+//					}
+//					mPrefs.edit().putString(Emulator.pref_bootdisk, disk).apply();
+//					Emulator.bootdisk = disk;
+//				}
+//			}
+//
+//			public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+//			}
+//
+//			public void onTextChanged(CharSequence s, int start, int before, int count) {
+//			}
+//		});
 
 		final CompoundButton fps_opt = (CompoundButton) getView().findViewById(R.id.fps_option);
 		OnCheckedChangeListener fps_options = new OnCheckedChangeListener() {
@@ -721,7 +721,7 @@ public class OptionsFragment extends Fragment {
 		mPrefs.edit().remove(Emulator.pref_pvrrender).apply();
 		mPrefs.edit().remove(Emulator.pref_syncedrender).apply();
 		mPrefs.edit().remove(Emulator.pref_modvols).apply();
-		mPrefs.edit().remove(Emulator.pref_bootdisk).apply();
+//		mPrefs.edit().remove(Emulator.pref_bootdisk).apply();
 		mPrefs.edit().remove(Config.pref_showfps).apply();
 		mPrefs.edit().remove(Config.pref_rendertype).apply();
 		mPrefs.edit().remove(Emulator.pref_nosound).apply();

--- a/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
@@ -747,34 +747,34 @@
                 </LinearLayout>
             </TableRow>
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:orientation="vertical" >
+            <!--<LinearLayout-->
+                <!--android:layout_width="match_parent"-->
+                <!--android:layout_height="wrap_content"-->
+                <!--android:layout_marginTop="10dp"-->
+                <!--android:orientation="vertical" >-->
 
-                <TextView
-                    android:id="@+id/boot_disk_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dip"
-                    android:layout_weight="1"
-                    android:text="@string/boot_disk" />
+                <!--<TextView-->
+                    <!--android:id="@+id/boot_disk_text"-->
+                    <!--android:layout_width="wrap_content"-->
+                    <!--android:layout_height="0dip"-->
+                    <!--android:layout_weight="1"-->
+                    <!--android:text="@string/boot_disk" />-->
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical" >
+                <!--<LinearLayout-->
+                    <!--android:layout_width="match_parent"-->
+                    <!--android:layout_height="wrap_content"-->
+                    <!--android:orientation="vertical" >-->
 
-                    <EditText
-                        android:id="@+id/boot_disk"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:ems="10"
-                        android:inputType="textPersonName" >
-                    </EditText>
-                </LinearLayout>
-            </LinearLayout>
+                    <!--<EditText-->
+                        <!--android:id="@+id/boot_disk"-->
+                        <!--android:layout_width="match_parent"-->
+                        <!--android:layout_height="wrap_content"-->
+                        <!--android:layout_weight="1"-->
+                        <!--android:ems="10"-->
+                        <!--android:inputType="textPersonName" >-->
+                    <!--</EditText>-->
+                <!--</LinearLayout>-->
+            <!--</LinearLayout>-->
 
             <TableRow
                 android:layout_marginTop="10dp"

--- a/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
@@ -747,34 +747,34 @@
                 </LinearLayout>
             </TableRow>
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:orientation="vertical" >
+            <!--<LinearLayout-->
+                <!--android:layout_width="match_parent"-->
+                <!--android:layout_height="wrap_content"-->
+                <!--android:layout_marginTop="10dp"-->
+                <!--android:orientation="vertical" >-->
 
-                <TextView
-                    android:id="@+id/boot_disk_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dip"
-                    android:layout_weight="1"
-                    android:text="@string/boot_disk" />
+                <!--<TextView-->
+                    <!--android:id="@+id/boot_disk_text"-->
+                    <!--android:layout_width="wrap_content"-->
+                    <!--android:layout_height="0dip"-->
+                    <!--android:layout_weight="1"-->
+                    <!--android:text="@string/boot_disk" />-->
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical" >
+                <!--<LinearLayout-->
+                    <!--android:layout_width="match_parent"-->
+                    <!--android:layout_height="wrap_content"-->
+                    <!--android:orientation="vertical" >-->
 
-                    <EditText
-                        android:id="@+id/boot_disk"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:ems="10"
-                        android:inputType="textPersonName" >
-                    </EditText>
-                </LinearLayout>
-            </LinearLayout>
+                    <!--<EditText-->
+                        <!--android:id="@+id/boot_disk"-->
+                        <!--android:layout_width="match_parent"-->
+                        <!--android:layout_height="wrap_content"-->
+                        <!--android:layout_weight="1"-->
+                        <!--android:ems="10"-->
+                        <!--android:inputType="textPersonName" >-->
+                    <!--</EditText>-->
+                <!--</LinearLayout>-->
+            <!--</LinearLayout>-->
 
             <TableRow
                 android:layout_marginTop="10dp"


### PR DESCRIPTION
This option saves a path for an unimplemented feature. Rather than continue to field questions about how to use it because it is not connected to anything, it is better to disable it for now.