### PR TITLE
evdev: Print a warning if a key is not configured

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -118,12 +118,13 @@
 			strstr(keycode.c_str(), "BTN_") != NULL ||
 			strstr(keycode.c_str(), "ABS_") != NULL)
 		{
-			if(libevdev_available)
+			if (libevdev_available)
 			{
 				int type = ((strstr(keycode.c_str(), "ABS_") != NULL) ? EV_ABS : EV_KEY);
 				code = libevdev_event_code_from_name(type, keycode.c_str());
 			}
-			if(code < 0)
+			
+			if (code < 0)
 			{
 				printf("evdev: failed to find keycode for '%s'\n", keycode.c_str());
 			}
@@ -131,27 +132,34 @@
 			{
 				printf("%s = %s (%d)\n", dc_key.c_str(), keycode.c_str(), code);
 			}
-			return code;
 		}
-
-		code = cfg->get_int(section, dc_key, -1);
-		if(code >= 0)
+		else
 		{
-			char* name = NULL;
-			if(libevdev_available)
+			code = cfg->get_int(section, dc_key, -1);
+			if(code >= 0)
 			{
-				int type = ((strstr(dc_key.c_str(), "axis_") != NULL) ? EV_ABS : EV_KEY);
-				name = (char*)libevdev_event_code_get_name(type, code);
-			}
-			if (name != NULL)
-			{
-				printf("%s = %s (%d)\n", dc_key.c_str(), name, code);
-			}
-			else
-			{
-				printf("%s = %d\n", dc_key.c_str(), code);
+				char* name = NULL;
+				
+				if (libevdev_available)
+				{
+					int type = ((strstr(dc_key.c_str(), "axis_") != NULL) ? EV_ABS : EV_KEY);
+					name = (char*)libevdev_event_code_get_name(type, code);
+				}
+				
+				if (name != NULL)
+				{
+					printf("%s = %s (%d)\n", dc_key.c_str(), name, code);
+				}
+				else
+				{
+					printf("%s = %d\n", dc_key.c_str(), code);
+				}
 			}
 		}
+		
+		if (code < 0)
+			printf("WARNING: %s/%s not configured!\n", section.c_str(), dc_key.c_str());
+		
 		return code;
 	}
 


### PR DESCRIPTION
Currently one does not necessary notice if a button/axis is unconfigured, so print a warning for each unassigned button.

Possible output:
````
btn_a = KEY_LEFTSHIFT (42)
btn_b = KEY_RIGHTCTRL (97)
WARNING: dreamcast/btn_c not configured!
WARNING: dreamcast/btn_d not configured!
btn_x = KEY_LEFTCTRL (29)
btn_y = KEY_LEFTALT (56)
WARNING: dreamcast/btn_z not configured!
btn_start = KEY_1 (2)
btn_escape = KEY_J (36)
btn_dpad1_left = KEY_LEFT (105)
btn_dpad1_right = KEY_RIGHT (106)
btn_dpad1_up = KEY_UP (103)
btn_dpad1_down = KEY_DOWN (108)
WARNING: dreamcast/btn_dpad2_left not configured!
WARNING: dreamcast/btn_dpad2_right not configured!
WARNING: dreamcast/btn_dpad2_up not configured!
WARNING: dreamcast/btn_dpad2_down not configured!
btn_trigger_left = KEY_SPACE (57)
WARNING: compat/btn_trigger_right not configured!
WARNING: compat/axis_dpad1_x not configured!
WARNING: compat/axis_dpad1_y not configured!
WARNING: compat/axis_dpad2_x not configured!
WARNING: compat/axis_dpad2_y not configured!
WARNING: dreamcast/axis_x not configured!
WARNING: dreamcast/axis_y not configured!
WARNING: dreamcast/axis_trigger_left not configured!
WARNING: dreamcast/axis_trigger_right not configured!
````