### PR TITLE
X11: Values <= 0 disable keyboard

### DIFF
--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -180,7 +180,9 @@ void input_x11_init()
 	x11_keymap[KEY_F] = DC_AXIS_LT;
 	x11_keymap[KEY_V] = DC_AXIS_RT;
 	
-	x11_keyboard_input = cfgLoadInt("input", "enable_x11_keyboard", 1);
+	x11_keyboard_input = (cfgLoadInt("input", "enable_x11_keyboard", 1) >= 1);
+	if (!x11_keyboard_input)
+		printf("X11 Keyboard input disabled by config.\n");
 }
 
 void x11_window_create()


### PR DESCRIPTION
Value -1 for example doesn't disable X11 keyboard input, only 0 does (non zero = enabled).

Changed that behavior to match other settings (where -1 means disabled, ``joystick_device_id`` f.e.) so that every value above zero means enabled and zero or less means disabled.

Also print an information if the X11 keyboard is disabled (like with legacy joystick support).

I noticed this investigating #1273.