### PR TITLE
Travis: increase depth over fetching full repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 - test -z "$encrypted_c726d225a9d9_key" || mv debug.keystore ~/.android/debug.keystore
 before_script: 
 script:
-- git fetch --unshallow
+- git fetch --depth 2
 - cd shell/android-studio
 - export NUMBER_OF_PROCESSORS=2
 - sudo chmod 755 travis-build.sh


### PR DESCRIPTION
Assuming the issue was that it could not access the "parent" commits, but any sliver of time that can be trimmed from the current build is desired.