### PR TITLE
evdev/dupcheck: Don't check unassigned buttons

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -196,30 +196,34 @@
 		};
 		return mapping;
 	}
-	
+
 	bool input_evdev_button_assigned(EvdevControllerMapping* mapping, int button)
 	{
-		return ((mapping->Btn_A == button) 
-			|| (mapping->Btn_B == button) 
-			|| (mapping->Btn_C == button) 
-			|| (mapping->Btn_D == button) 
-			|| (mapping->Btn_X == button) 
-			|| (mapping->Btn_Y == button) 
-			|| (mapping->Btn_Z == button) 
-			|| (mapping->Btn_Start == button) 
-			|| (mapping->Btn_Escape == button) 
-			|| (mapping->Btn_DPad_Left == button) 
-			|| (mapping->Btn_DPad_Right == button) 
-			|| (mapping->Btn_DPad_Up == button) 
-			|| (mapping->Btn_DPad_Down == button) 
-			|| (mapping->Btn_DPad2_Left == button) 
-			|| (mapping->Btn_DPad2_Right == button) 
-			|| (mapping->Btn_DPad2_Up == button) 
-			|| (mapping->Btn_DPad2_Down == button) 
-			|| (mapping->Btn_Trigger_Left == button) 
+		// Don't check unassigned buttons
+		if (button == -1)
+			return false;
+
+		return ((mapping->Btn_A == button)
+			|| (mapping->Btn_B == button)
+			|| (mapping->Btn_C == button)
+			|| (mapping->Btn_D == button)
+			|| (mapping->Btn_X == button)
+			|| (mapping->Btn_Y == button)
+			|| (mapping->Btn_Z == button)
+			|| (mapping->Btn_Start == button)
+			|| (mapping->Btn_Escape == button)
+			|| (mapping->Btn_DPad_Left == button)
+			|| (mapping->Btn_DPad_Right == button)
+			|| (mapping->Btn_DPad_Up == button)
+			|| (mapping->Btn_DPad_Down == button)
+			|| (mapping->Btn_DPad2_Left == button)
+			|| (mapping->Btn_DPad2_Right == button)
+			|| (mapping->Btn_DPad2_Up == button)
+			|| (mapping->Btn_DPad2_Down == button)
+			|| (mapping->Btn_Trigger_Left == button)
 			|| (mapping->Btn_Trigger_Right == button));
 	}
-	
+
 	bool input_evdev_button_duplicate_button(EvdevControllerMapping* mapping1, EvdevControllerMapping* mapping2)
 	{
 		return (input_evdev_button_assigned(mapping1, mapping2->Btn_A)


### PR DESCRIPTION
There is no need to check unassigned buttons (dpad2, D, Z f. e.) and this caused false positives.

Also removes the trailing white-spaces.

Follow up of #1277.