### PR TITLE
Fixes compiling with GLES and X11

### DIFF
--- a/core/linux-dist/x11.cpp
+++ b/core/linux-dist/x11.cpp
@@ -381,12 +381,14 @@ void x11_window_destroy()
 	}
 	if (x11_disp)
 	{
+#if !defined(GLES)
 		if (x11_glc)
 		{
 			glXMakeCurrent((Display*)x11_disp, None, NULL);
 			glXDestroyContext((Display*)x11_disp, (GLXContext)x11_glc);
 			x11_glc = NULL;
 		}
+#endif
 		XCloseDisplay((Display*)x11_disp);
 		x11_disp = NULL;
 	}


### PR DESCRIPTION
Without those changes, it's not possible to compile reicast with GLES support and X11.
The resulting binary is working fine.