### PR TITLE
RFC: Exemplary .clang-format file

### DIFF
--- a/core/.clang-format
+++ b/core/.clang-format
@@ -1,0 +1,27 @@
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+TabWidth: 4
+UseTab: Always
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortBlocksOnASingleLine: false
+PointerAlignment: Left
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+SortIncludes: false


### PR DESCRIPTION
Very basic clang-format configuration file.

Indentation is via Tabs which are 4 columns wide.
Brackets are in the next line.

Example:
````cpp
if (condition)
{
    something();
}
````

However I'm not sure about the precompiler settings, whichbare currently "no indentation":
````cpp
#if DEFINE
#if SUBDEFINE
#endif
#else
#endif
````

I would have liked
````cpp
#if DEFINE
    #if SUBDEFINE
    #endif
#else
#endif
````

But the only setting I found would have made the code look like
````cpp
#if DEFINE
#    if SUBDEFINE
#    endif
#else
#endif
````

See #1240.