### PR TITLE
Android: Pass microphone setup through controller

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNIActivity.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNIActivity.java
@@ -92,6 +92,10 @@ public class GL2JNIActivity extends Activity {
         boolean player2connected = false;
         boolean player3connected = false;
         boolean player4connected = false;
+        int p1periphs[] = {
+                1, // Hardcoded VMU
+                prefs.getBoolean(Gamepad.pref_mic, false) ? 2 : 1
+        };
         int p2periphs[] = {
                 prefs.getInt(Gamepad.p2_peripheral + 1, 0),
                 prefs.getInt(Gamepad.p2_peripheral + 2, 0)
@@ -127,7 +131,7 @@ public class GL2JNIActivity extends Activity {
 
         JNIdc.initControllers(
                 new boolean[] { player2connected, player3connected, player4connected },
-                new int[][] { p2periphs, p3periphs, p4periphs });
+                new int[][] { p1periphs, p2periphs, p3periphs, p4periphs });
         int joys[] = InputDevice.getDeviceIds();
         for (int joy: joys) {
             String descriptor = null;

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNINative.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNINative.java
@@ -93,6 +93,10 @@ public class GL2JNINative extends NativeActivity {
 		boolean player2connected = false;
 		boolean player3connected = false;
 		boolean player4connected = false;
+		int p1periphs[] = {
+				1, // Hardcoded VMU
+				prefs.getBoolean(Gamepad.pref_mic, false) ? 2 : 1
+		};
 		int p2periphs[] = {
 				prefs.getInt(Gamepad.p2_peripheral + 1, 0),
 				prefs.getInt(Gamepad.p2_peripheral + 2, 0)
@@ -129,7 +133,7 @@ public class GL2JNINative extends NativeActivity {
 
 		JNIdc.initControllers(
 				new boolean[] { player2connected, player3connected, player4connected },
-				new int[][] { p2periphs, p3periphs, p4periphs });
+				new int[][] { p1periphs, p2periphs, p3periphs, p4periphs });
 		int joys[] = InputDevice.getDeviceIds();
 		for (int joy : joys) {
 			String descriptor = descriptor = InputDevice.getDevice(joy).getDescriptor();

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/Config.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/Config.java
@@ -10,8 +10,6 @@ public class Config {
 	public static final String pref_games = "game_directory";
 	public static final String pref_theme = "button_theme";
 
-	public static final String pref_gamedetails = "game_details";
-
 	public static final String pref_showfps = "show_fps";
 	public static final String pref_rendertype = "render_type";
 	public static final String pref_renderdepth = "depth_render";

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/InputFragment.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/InputFragment.java
@@ -1,5 +1,6 @@
 package com.reicast.emulator.config;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
@@ -7,10 +8,12 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Vibrator;
 import android.preference.PreferenceManager;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.util.Log;
 import android.view.InputDevice;
@@ -35,6 +38,7 @@ import com.reicast.emulator.R;
 import com.reicast.emulator.periph.Gamepad;
 
 public class InputFragment extends Fragment {
+	private static final int PERMISSION_REQUEST = 1001;
 
 	private int listenForButton = 0;
 	private AlertDialog alertDialogSelectController;
@@ -148,6 +152,13 @@ public class InputFragment extends Fragment {
 					.setOnCheckedChangeListener(new OnCheckedChangeListener() {
 						public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
 							mPrefs.edit().putBoolean(Gamepad.pref_mic, isChecked).apply();
+							if (isChecked && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+									ActivityCompat.requestPermissions(getActivity(),
+											new String[] {
+													Manifest.permission.RECORD_AUDIO
+											},
+											PERMISSION_REQUEST);
+							}
 						}
 					});
 		} else {

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
@@ -178,25 +178,6 @@ public class OptionsFragment extends Fragment {
 		reios_opt.setChecked(mPrefs.getBoolean(Emulator.pref_usereios, false));
 		reios_opt.setOnCheckedChangeListener(reios_options);
 
-		OnCheckedChangeListener details_options = new OnCheckedChangeListener() {
-
-			public void onCheckedChanged(CompoundButton buttonView,
-										 boolean isChecked) {
-				mPrefs.edit().putBoolean(Config.pref_gamedetails, isChecked).apply();
-				if (!isChecked) {
-					File dir = new File(getActivity().getExternalFilesDir(null), "images");
-					for (File file : dir.listFiles()) {
-						if (!file.isDirectory()) {
-							file.delete();
-						}
-					}
-				}
-			}
-		};
-		CompoundButton details_opt = (CompoundButton) getView().findViewById(R.id.details_option);
-		details_opt.setChecked(mPrefs.getBoolean(Config.pref_gamedetails, false));
-		details_opt.setOnCheckedChangeListener(details_options);
-
 		Button gameBrowse = (Button) getView().findViewById(R.id.browse_game_path);
 
 		final EditText editGames = (EditText) getView().findViewById(R.id.game_path);
@@ -694,7 +675,6 @@ public class OptionsFragment extends Fragment {
 
 	private void resetEmuSettings() {
 		mPrefs.edit().remove(Emulator.pref_usereios).apply();
-		mPrefs.edit().remove(Config.pref_gamedetails).apply();
 		mPrefs.edit().remove(Emulator.pref_nativeact).apply();
 		mPrefs.edit().remove(Emulator.pref_dynarecopt).apply();
 		mPrefs.edit().remove(Emulator.pref_unstable).apply();

--- a/shell/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -275,7 +275,7 @@ MapleDeviceType GetMapleDeviceType(int value)
 void os_SetupInput()
 {
     // Create first controller
-    mcfg_CreateController(0, MDT_SegaVMU, MDT_SegaVMU);
+    mcfg_CreateController(0, MDT_SegaVMU, GetMapleDeviceType(controller_periphs[0][1]));
 
     // Add additonal controllers
     for (int i = 0; i < 3; i++)
@@ -402,23 +402,6 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_setupMic(JNIEnv *env,
 {
     sipemu = env->NewGlobalRef(sip);
     getmicdata = env->GetMethodID(env->GetObjectClass(sipemu),"getData","()[B");
-
-    // Obligatory microphone for controller A-2
-    delete MapleDevices[0][1];
-    mcfg_Create(MDT_Microphone, 0, 1);
-
-    // Allow additional microphones, if desired
-    for (int i = 0; i < 3; i++)
-    {
-        if (controller_periphs[i + 1][0] == MDT_Microphone) {
-            delete MapleDevices[i + 1][0];
-            mcfg_Create(MDT_Microphone, i + 1, 0);
-        }
-        if (controller_periphs[i + 1][1] == MDT_Microphone) {
-            delete MapleDevices[i + 1][1];
-            mcfg_Create(MDT_Microphone, i + 1, 1);
-        }
-    }
 }
 
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_setupVmu(JNIEnv *env,jobject obj,jobject vmu)

--- a/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
@@ -145,41 +145,6 @@
             </LinearLayout>
         </LinearLayout>
 
-        <TableLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="6dp"
-            android:stretchColumns="*" >
-
-            <TableRow
-                android:layout_marginTop="10dp"
-                android:gravity="center_vertical" >
-
-                <TextView
-                    android:id="@+id/details_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0.5"
-                    android:ems="10"
-                    android:gravity="center_vertical|left"
-                    android:text="@string/select_details" />
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="right"
-                    android:orientation="vertical" >
-
-                    <Switch
-                        android:id="@+id/details_option"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:focusable="true" />
-                </LinearLayout>
-            </TableRow>
-        </TableLayout>
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
@@ -145,41 +145,6 @@
             </LinearLayout>
         </LinearLayout>
 
-        <TableLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="6dp"
-            android:stretchColumns="*" >
-
-            <TableRow
-                android:layout_marginTop="10dp"
-                android:gravity="center_vertical" >
-
-                <TextView
-                    android:id="@+id/details_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="0.5"
-                    android:ems="10"
-                    android:gravity="center_vertical|left"
-                    android:text="@string/select_details" />
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="right"
-                    android:orientation="vertical" >
-
-                    <Checkbox
-                        android:id="@+id/details_option"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:focusable="true" />
-                </LinearLayout>
-            </TableRow>
-        </TableLayout>
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/shell/android-studio/reicast/src/main/res/values/strings.xml
+++ b/shell/android-studio/reicast/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
     <string name="experimental_opts">Experimental (May cause widespread panic)</string>
     <string name="select_reios">Use reios BIOS</string>
     <string name="select_bios">BIOS Region (dc_flash[X].bin)</string>
-    <string name="select_details">Enable Game Details</string>
     <string name="select_native">Native Gamepad Mode [No OSD]</string>
     <string name="select_dynarec">Dynamic Recompiler</string>
     <string name="select_unstable">Unstable Optimisations</string>


### PR DESCRIPTION
This will maintain restricting access to direct creation, while still allowing the workaround of setting the microphone to an obligatory port.