### PR TITLE
Fixes compiling if evdev is disabled

### DIFF
--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -37,9 +37,10 @@
 
 #if defined(USE_EVDEV)
 	#include "linux-dist/evdev.h"
-	#include "hw/maple/maple_cfg.h"
 	#include "hw/maple/maple_devs.h"
 #endif
+
+#include "hw/maple/maple_cfg.h"
 
 #if defined(USE_JOYSTICK)
 	#include "linux-dist/joystick.h"


### PR DESCRIPTION
If USE_EVDEV is not defined then it will complain about MapleDeviceType not being defined (see line 108 in core/linux-dist/main.cpp)...
The resulting binary still works btw but i've only tested it against Void linux Musl x86_64 so pls test thx