### PR TITLE
WIP: Fixes for Musl

### DIFF
--- a/core/deps/ifaddrs/ifaddrs.h
+++ b/core/deps/ifaddrs/ifaddrs.h
@@ -44,11 +44,13 @@ struct ifaddrs {
 #define	ifa_broadaddr	ifa_dstaddr	/* broadcast address interface */
 #endif
 
-#include <sys/cdefs.h>
-
-__BEGIN_DECLS
+#ifdef _cplusplus 
+extern "C" {
+#endif
 extern int getifaddrs(struct ifaddrs **ifap);
 extern void freeifaddrs(struct ifaddrs *ifa);
-__END_DECLS
+#ifdef _cplusplus 
+}
+#endif
 
 #endif

--- a/core/deps/libwebsocket/private-libwebsockets.h
+++ b/core/deps/libwebsocket/private-libwebsockets.h
@@ -203,7 +203,6 @@ typedef unsigned __int64 u_int64_t;
 #else
 
 #include <sys/stat.h>
-#include <sys/cdefs.h>
 #include <sys/time.h>
 
 #if defined(__APPLE__)

--- a/core/deps/libwebsocket/sha-1.c
+++ b/core/deps/libwebsocket/sha-1.c
@@ -99,8 +99,6 @@ static const unsigned int _K[] =
 		sha1_step(ctxt);		\
 	}
 
-static void sha1_step __P((struct sha1_ctxt *));
-
 static void
 sha1_step(struct sha1_ctxt *ctxt)
 {

--- a/core/oslib/audiobackend_oss.cpp
+++ b/core/oslib/audiobackend_oss.cpp
@@ -2,11 +2,7 @@
 #ifdef USE_OSS
 #include <sys/ioctl.h>
 #include <sys/fcntl.h>
-#ifdef TARGET_BSD
 #include <unistd.h>
-#else
-#include <sys/unistd.h>
-#endif
 #include <sys/soundcard.h>
 
 static int oss_audio_fd = -1;


### PR DESCRIPTION
This allows it to compile & run on Void Linux musl (and possibly other musl-based linux distribution such as Alpine Linux) either via cmake or the makefile.
The file sys/cdefs.h in musl does not exist (see https://wiki.musl-libc.org/faq.html, Q: When compiling something against musl, I get error messages about sys/cdefs.h) so it needs to be removed.
#include <unistd.h> does not exist on Void linux musl either and even on glibc, GCC recommends that we use unistd.h instead rather than sys/unistd.h. (at least on recent versions of GCC on a modern distribution that is...)

There's also this line of code in core/deps/libwebsocket/sha-1.c
static void sha1_step __P((struct sha1_ctxt *));

Upstream does not have this line of code in question and it builds fine without it.

It's possible that removing <sys/cdefs.h> could prevent it to compile on other platforms. 
It compiles and works on both Devuan (Glibc) & Void linux musl but pls test thx on other platforms and i hope i can gather feedback on how to properly fix this.