### PR TITLE
Mac: Reference "official" preprocessor directives

### DIFF
--- a/core/emitter/x86_emitter.h
+++ b/core/emitter/x86_emitter.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "types.h"
 #include "x86_op_classes.h"
+#if HOST_OS == OS_DARWIN
+	#include <TargetConditionals.h>
+#endif
 
 using namespace std;
 //Oh god , x86 is a sooo badly designed opcode arch -_-
@@ -230,7 +233,7 @@ struct /*__declspec(dllexport)*/  x86_ptr_imm
 	}
 
 #if HOST_CPU != CPU_X64
-#ifndef WIN32
+#if !defined(WIN32) && !defined(TARGET_OS_MAC)
 	template<typename Rv, typename ...Args>
 	x86_ptr_imm(Rv(* ptr)(Args...))
 	{

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -5,6 +5,7 @@
 #if HOST_OS == OS_DARWIN
 	#define _XOPEN_SOURCE 1
 	#define __USE_GNU 1
+	#include <TargetConditionals.h>
 #endif
 #if !defined(TARGET_NACL32)
 #include <poll.h>
@@ -294,7 +295,7 @@ void enable_runfast()
 }
 
 void linux_fix_personality() {
-        #if !defined(TARGET_BSD) && !defined(_ANDROID) && !defined(TARGET_OS_IPHONE) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN)
+        #if !defined(TARGET_BSD) && !defined(_ANDROID) && !defined(TARGET_OS_MAC) && !defined(TARGET_NACL32) && !defined(TARGET_EMSCRIPTEN)
           printf("Personality: %08X\n", personality(0xFFFFFFFF));
           personality(~READ_IMPLIES_EXEC & personality(0xFFFFFFFF));
           printf("Updated personality: %08X\n", personality(0xFFFFFFFF));


### PR DESCRIPTION
This allows checking against the whole library of definitions specifically for Mac, including the wondrous `TARGET_OS_MAC` that checks for anything Apple-based.