### PR TITLE
evdev: Search for libevdev.so.2 first

### DIFF
--- a/core/linux-dist/evdev.cpp
+++ b/core/linux-dist/evdev.cpp
@@ -21,12 +21,12 @@
 	void load_libevdev()
 	{
 		if (libevdev_tried)
-		{
 			return;
-		}
 
 		libevdev_tried = true;
-		void* lib_handle = dlopen("libevdev.so", RTLD_NOW);
+		void* lib_handle = dlopen("libevdev.so.2", RTLD_NOW);
+		if (!lib_handle) // libevdev.so.2 not found, fallback to libevdev.so
+			lib_handle = dlopen("libevdev.so", RTLD_NOW);
 
 		bool failed = false;
 
@@ -56,7 +56,7 @@
 			}
 		}
 
-		if(failed)
+		if (failed)
 		{
 			puts("WARNING: libevdev is not available. You'll not be able to use button names instead of numeric codes in your controller mappings!\n");
 			return;


### PR DESCRIPTION
Many Linux distributions provide livevdev.so.2 only so check that first.

See https://packages.debian.org/sid/amd64/libevdev2/filelist for Debian. You would need to create a symlink yourself or install ``libevdev-dev`` (see https://packages.debian.org/sid/amd64/libevdev-dev/filelist) which no normal user should have installed as it's a developer package.

Fixes #1336