### PR TITLE
evdev: Fix off by one error

### DIFF
--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -134,8 +134,8 @@ MapleDeviceType GetMapleDeviceType(int value, int port)
 			MapleDeviceType result = MDT_None;
 			string result_type = "None";
 
-			// Controller in port 1 defaults to VMU for Maple device, all other to None
-			if (port == 1)
+			// Controller in port 0 (player1) defaults to VMU for Maple device, all other to None
+			if (port == 0)
 			{
 				result_type = "VMU";
 				result = MDT_SegaVMU;


### PR DESCRIPTION
The port for player1 is 0, not 1 (we're zero based here).

This fixes a bug introduced in #1288 / #1308.

Fixes #1335 