### PR TITLE
Round TA context to 1MB at ListInit time so it is found when rendering

### DIFF
--- a/core/hw/pvr/ta.cpp
+++ b/core/hw/pvr/ta.cpp
@@ -275,13 +275,13 @@ static OnLoad ol_fillfsm(&fill_fsm);
 
 void ta_vtx_ListCont()
 {
-	SetCurrentTARC(TA_ISP_BASE);
+	SetCurrentTARC(TA_CURRENT_CTX);
 
 	ta_cur_state=TAS_NS;
 }
 void ta_vtx_ListInit()
 {
-	SetCurrentTARC(TA_ISP_BASE);
+	SetCurrentTARC(TA_CURRENT_CTX);
 	ta_tad.ClearPartial();
 
 	ta_cur_state=TAS_NS;


### PR DESCRIPTION
Fixes black screen in NFL 2K2, NBA 2K2, Oooga Booga, Floigan Bros. and probably more Visual Concepts games.