### PR TITLE
Detect TA overruns and cancel the rendering. Increase TA data size

### DIFF
--- a/core/hw/pvr/ta_ctx.h
+++ b/core/hw/pvr/ta_ctx.h
@@ -159,12 +159,12 @@ struct TA_context
 	{
 		tad.Reset((u8*)OS_aligned_malloc(32, 8*1024*1024));
 
-		rend.verts.InitBytes(1024*1024,&rend.Overrun); //up to 1 mb of vtx data/frame = ~ 38k vtx/frame
-		rend.idx.Init(60*1024,&rend.Overrun);			//up to 60K indexes ( idx have stripification overhead )
+		rend.verts.InitBytes(2*1024*1024,&rend.Overrun); //up to 2 mb of vtx data/frame = ~ 76k vtx/frame
+		rend.idx.Init(120*1024,&rend.Overrun);			//up to 120K indexes ( idx have stripification overhead )
 		rend.global_param_op.Init(4096,&rend.Overrun);
 		rend.global_param_pt.Init(4096,&rend.Overrun);
 		rend.global_param_mvo.Init(4096,&rend.Overrun);
-		rend.global_param_tr.Init(4096,&rend.Overrun);
+		rend.global_param_tr.Init(8192,&rend.Overrun);
 
 		rend.modtrig.Init(8192,&rend.Overrun);
 		

--- a/core/hw/pvr/ta_vtx.cpp
+++ b/core/hw/pvr/ta_vtx.cpp
@@ -1437,8 +1437,6 @@ int ta_parse_cnt = 0;
 */
 bool ta_parse_vdrc(TA_context* ctx)
 {
-	bool rv=false;
-
 	verify( vd_ctx == 0);
 	vd_ctx = ctx;
 	vd_rc = vd_ctx->rend;
@@ -1457,15 +1455,18 @@ bool ta_parse_vdrc(TA_context* ctx)
 
 		}
 		while(ta_data<=ta_data_end);
-
-		rv = true; //whatever
 	}
+	bool overrun = ctx->rend.Overrun;
 
 	vd_ctx->rend = vd_rc;
 	vd_ctx = 0;
 	ctx->rend_inuse.Unlock();
 
-	return rv;
+	ctx->rend.Overrun = overrun;
+	if (overrun)
+		printf("Warning: TA context overrun\n");
+
+	return !overrun;
 }
 
 


### PR DESCRIPTION
 Increase vertices, indices and translucent polygons max count.

Fixes crashes in D2 and Triggerheart Exelica:
https://github.com/reicast/gamedb/issues/123
https://github.com/reicast/gamedb/issues/63
