### PR TITLE
Do not crash on unaligned VRAM read access. Just return 0.

### DIFF
--- a/core/hw/holly/sb_mem.cpp
+++ b/core/hw/holly/sb_mem.cpp
@@ -165,7 +165,9 @@ T DYNACALL ReadMem_area0(u32 addr)
 		else if (likely((addr>= 0x005F8000) && (addr<=0x005F9FFF))) //	:TA / PVR Core Reg.
 		{
 			//EMUERROR2("Read from area0_32 not implemented [TA / PVR Core Reg], addr=%x",addr);
-			verify(sz==4);
+			if (sz != 4)
+				// House of the Dead 2
+				return 0;
 			return (T)pvr_ReadReg(addr);
 		}
 	}


### PR DESCRIPTION
Fixes House of the Dead 2