### PR TITLE
Some games send TA data without calling ListInit first. Don't crash in that case

### DIFF
--- a/core/hw/pvr/ta.cpp
+++ b/core/hw/pvr/ta.cpp
@@ -294,6 +294,12 @@ void ta_vtx_SoftReset()
 INLINE
 void DYNACALL ta_thd_data32_i(void* data)
 {
+	if (ta_ctx == NULL)
+	{
+		printf("Warning: data sent to TA prior to ListInit. Implied\n");
+		ta_vtx_ListInit();
+	}
+
 	simd256_t* dst = (simd256_t*)ta_tad.thd_data;
 	simd256_t* src = (simd256_t*)data;
 


### PR DESCRIPTION
Fixes crashes in Looney Tunes Space Race, Test Drive Le Mans and others.