### PR TITLE
README/Snap: Fix URL to snap/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ make
 ```
 
 ### Using snap
-- Refer to our [snap README](https:github.com/reicast/reicast-emulator/snap/README.md)
+- Refer to our [snap README](https://github.com/reicast/reicast-emulator/tree/master/snap/README.md)
 
 Translations
 ------------


### PR DESCRIPTION
Fixes the URL to the snap/README.md in our main README.md