### PR TITLE
CDI: coreio file handle leak in cdi image reader

### DIFF
--- a/core/imgread/cdi.cpp
+++ b/core/imgread/cdi.cpp
@@ -155,6 +155,7 @@ Disc* cdi_parse(const wchar* file)
 
 		image.remaining_sessions--;
 	}
+	core_fclose(fsource);
 
 	rv->type=GuessDiscType(CD_M1,CD_M2,CD_DA);
 


### PR DESCRIPTION
Adopt https://github.com/reicast/reicast-emulator/commit/bffccac5a65860a84e8eb59cc689795f515fee9a from @flyinghead 