### PR TITLE
Clipping switch in settings added - Android (multiplayer/split screen fixed)

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
@@ -23,6 +23,7 @@ public class Emulator extends Application {
     public static final String pref_mipmaps = "use_mipmaps";
     public static final String pref_widescreen = "stretch_view";
     public static final String pref_frameskip = "frame_skip";
+    public static final String pref_clipping = "clipping";
     public static final String pref_pvrrender = "pvr_render";
     public static final String pref_syncedrender = "synced_render";
     public static final String pref_modvols = "modifier_volumes";
@@ -44,6 +45,7 @@ public class Emulator extends Application {
     public static boolean widescreen = false;
     public static boolean subdivide = false;
     public static int frameskip = 0;
+    public static boolean clipping = false;
     public static boolean pvrrender = false;
     public static boolean syncedrender = false;
     public static boolean modvols = true;
@@ -66,6 +68,7 @@ public class Emulator extends Application {
         Emulator.mipmaps = mPrefs.getBoolean(pref_mipmaps, mipmaps);
         Emulator.widescreen = mPrefs.getBoolean(pref_widescreen, widescreen);
         Emulator.frameskip = mPrefs.getInt(pref_frameskip, frameskip);
+        Emulator.clipping = mPrefs.getBoolean(pref_clipping, clipping);
         Emulator.pvrrender = mPrefs.getBoolean(pref_pvrrender, pvrrender);
         Emulator.syncedrender = mPrefs.getBoolean(pref_syncedrender, syncedrender);
         Emulator.bootdisk = mPrefs.getString(pref_bootdisk, bootdisk);
@@ -93,6 +96,7 @@ public class Emulator extends Application {
         JNIdc.widescreen(Emulator.widescreen ? 1 : 0);
         JNIdc.subdivide(Emulator.subdivide ? 1 : 0);
         JNIdc.frameskip(Emulator.frameskip);
+        JNIdc.clipping(Emulator.clipping ? 1 : 0);
         JNIdc.pvrrender(Emulator.pvrrender ? 1 : 0);
         JNIdc.syncedrender(Emulator.syncedrender ? 1 : 0);
         JNIdc.modvols(Emulator.modvols ? 1 : 0);

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/OptionsFragment.java
@@ -370,6 +370,16 @@ public class OptionsFragment extends Fragment {
 		limit_fps.setChecked(mPrefs.getBoolean(Emulator.pref_limitfps, Emulator.limitfps));
 		limit_fps.setOnCheckedChangeListener(limitfps_option);
 
+		OnCheckedChangeListener clipping_option = new OnCheckedChangeListener() {
+
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				mPrefs.edit().putBoolean(Emulator.pref_clipping, isChecked).apply();
+			}
+		};
+		CompoundButton clipping_fps = (CompoundButton) getView().findViewById(R.id.clipping_option);
+		clipping_fps.setChecked(mPrefs.getBoolean(Emulator.pref_clipping, Emulator.clipping));
+		clipping_fps.setOnCheckedChangeListener(clipping_option);
+
 		OnCheckedChangeListener mipmaps_option = new OnCheckedChangeListener() {
 
 			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -697,6 +707,7 @@ public class OptionsFragment extends Fragment {
 		mPrefs.edit().remove(Emulator.pref_mipmaps).apply();
 		mPrefs.edit().remove(Emulator.pref_widescreen).apply();
 		mPrefs.edit().remove(Emulator.pref_frameskip).apply();
+		mPrefs.edit().remove(Emulator.pref_clipping).apply();
 		mPrefs.edit().remove(Emulator.pref_pvrrender).apply();
 		mPrefs.edit().remove(Emulator.pref_syncedrender).apply();
 		mPrefs.edit().remove(Emulator.pref_bootdisk).apply();

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
@@ -44,6 +44,7 @@ public final class JNIdc
 	public static native void widescreen(int stretch);
 	public static native void subdivide(int subdivide);
 	public static native void frameskip(int frames);
+	public static native void clipping(int clipping);
 	public static native void pvrrender(int render);
 	public static native void syncedrender(int sync);
 	public static native void modvols(int volumes);

--- a/shell/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -52,6 +52,7 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_safemode(JNIEnv *env,
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_cable(JNIEnv *env,jobject obj, jint cable)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_region(JNIEnv *env,jobject obj, jint region)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_broadcast(JNIEnv *env,jobject obj, jint broadcast)  __attribute__((visibility("default")));
+JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_clipping(JNIEnv *env,jobject obj, jint clipping)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_limitfps(JNIEnv *env,jobject obj, jint limiter)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_nobatch(JNIEnv *env,jobject obj, jint nobatch)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_nosound(JNIEnv *env,jobject obj, jint noaudio)  __attribute__((visibility("default")));
@@ -126,6 +127,11 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_delayinterrupt(JNIEnv
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_mipmaps(JNIEnv *env,jobject obj, jint mipmaps)
 {
     settings.rend.UseMipmaps = mipmaps;
+}
+
+JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_clipping(JNIEnv *env,jobject obj, jint clipping)
+{
+	settings.rend.Clipping = clipping;
 }
 
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_widescreen(JNIEnv *env,jobject obj, jint stretch)

--- a/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout-v14/configure_fragment.xml
@@ -668,6 +668,34 @@
                 android:gravity="center_vertical" >
 
                 <TextView
+                    android:id="@+id/clipping_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.5"
+                    android:ems="10"
+                    android:gravity="center_vertical|left"
+                    android:text="@string/clipping" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="right"
+                    android:orientation="vertical" >
+
+                    <Switch
+                        android:id="@+id/clipping_option"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:focusable="true" />
+                </LinearLayout>
+            </TableRow>
+
+            <TableRow
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical" >
+
+                <TextView
                     android:id="@+id/render_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
+++ b/shell/android-studio/reicast/src/main/res/layout/configure_fragment.xml
@@ -668,6 +668,34 @@
                 android:gravity="center_vertical" >
 
                 <TextView
+                    android:id="@+id/clipping_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.5"
+                    android:ems="10"
+                    android:gravity="center_vertical|left"
+                    android:text="@string/clipping" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="right"
+                    android:orientation="vertical" >
+
+                    <Checkbox
+                        android:id="@+id/clipping_option"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:focusable="true" />
+                </LinearLayout>
+            </TableRow>
+
+            <TableRow
+                android:layout_marginTop="10dp"
+                android:gravity="center_vertical" >
+
+                <TextView
                     android:id="@+id/render_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/shell/android-studio/reicast/src/main/res/values/strings.xml
+++ b/shell/android-studio/reicast/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="select_sound">Disable Emulator Sound</string>
     <string name="select_depth">View Rendering Depth</string>
     <string name="boot_disk">Boot Disk (ie. Gameshark, Utopia)</string>
+    <string name="clipping">Clipping</string>
 
     <string name="reset_emu">Reset Emu</string>
     <string name="reset_emu_title">Reset Emulator Settings</string>


### PR DESCRIPTION
Clipping is disabled by default on Android platform, so I decided to add a switch in settings menu to be able to turn on this option (disabled by default). Clipping implementation by @flyinghead is already present in the master branch.

When clipping is disabled split screen / multiplayer mode is rather non-playable (THPS2):
![screenshot_2019-01-09-20-34-34-104_com reicast emulator](https://user-images.githubusercontent.com/5397997/50924957-41c75600-1451-11e9-9450-0b6a9073c2b5.png)

When we enable the clipping (THPS2):
![screenshot_2019-01-09-20-31-27-325_com reicast emulator](https://user-images.githubusercontent.com/5397997/50925002-5efc2480-1451-11e9-8e5b-b30e7ee14514.png)
