### PR TITLE
SDL: rumble support

### DIFF
--- a/core/sdl/sdl.h
+++ b/core/sdl/sdl.h
@@ -3,5 +3,6 @@
 
 extern void input_sdl_init();
 extern void input_sdl_handle(u32 port);
+extern void input_sdl_rumble(u32 port, u16 pow_strong, u16 pow_weak);
 extern void sdl_window_create();
 extern void sdl_window_set_text(const char* text);


### PR DESCRIPTION
This adds support for rumble to the SDL backend.
It does not however attach a purupuru/rumble pack.

This is one part to make the SDL input backend on par with the evdev backend (#1371, #340).
After that work is done, I think we can work on a more unified input backend implementation like the audiobackend (see #843, #823).