### PR TITLE
Fix: Instead of booting a game, reicast opens bios menu

### DIFF
--- a/shell/android-studio/reicast/src/main/res/xml/provider_paths.xml
+++ b/shell/android-studio/reicast/src/main/res/xml/provider_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <files-path name="files_root" path="."/>
-    <external-path name="external_root" path="."/>
+    <external-path name="external_files" path="."/>
     <root-path name="external_files" path="/storage/" />
 </paths>


### PR DESCRIPTION
This PR fixes game booting issue on Android: https://github.com/reicast/reicast-emulator/issues/1488 by partially reverting commit: 4a3bec95f8ae9aadda10c6e5ae0303b3754e0a14

Please review and merge.

@AbandonedCart FYI
