### PR TITLE
Android: fix full-screen shadow on some platforms

### DIFF
--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNIActivity.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/GL2JNIActivity.java
@@ -203,7 +203,7 @@ public class GL2JNIActivity extends Activity {
 
         // Create the actual GLES view
         mView = new GL2JNIView(GL2JNIActivity.this, fileName, false,
-                prefs.getInt(Config.pref_renderdepth, 24), 0, false);
+                prefs.getInt(Config.pref_renderdepth, 24), 8, false);
         setContentView(mView);
 
         //setup mic

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/EditVJoyActivity.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/config/EditVJoyActivity.java
@@ -64,7 +64,7 @@ public class EditVJoyActivity extends Activity {
 
 		// Create the actual GLES view
 		mView = new GL2JNIView(EditVJoyActivity.this, fileName, false,
-				prefs.getInt(Config.pref_renderdepth, 24), 0, true);
+				prefs.getInt(Config.pref_renderdepth, 24), 8, true);
 		mView.setFpsDisplay(null);
 		setContentView(mView);
 

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/GLCFactory.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/emu/GLCFactory.java
@@ -121,7 +121,7 @@ public class GLCFactory {
                 int s = findConfigAttrib(egl,display,config,EGL10.EGL_STENCIL_SIZE,0);
 
                 // We need at least mDepthSize and mStencilSize bits
-                if (d>=mDepthSize || s>=mStencilSize)
+                if (d >= mDepthSize && s >= mStencilSize)
                 {
                     // We want an *exact* match for red/green/blue/alpha
                     int r = findConfigAttrib(egl,display,config,EGL10.EGL_RED_SIZE,  0);


### PR DESCRIPTION
This fixes #1451 by cherry-picking https://github.com/reicast/reicast-emulator/commit/9c4085ee1ee42f85fc31aaf0bc2e01e3e16024d8 from @flyinghead and correcting the stencil buffer size in the Java code.