### PR TITLE
gdi: set correct CTRL value in TOC

### DIFF
--- a/core/imgread/gdi.cpp
+++ b/core/imgread/gdi.cpp
@@ -137,6 +137,7 @@ Disc* load_gdi(const char* file)
 		t.StartFAD=FADS+150;
 		t.EndFAD=0;		//fill it in
 		t.file=0;
+		t.CTRL = CTRL;
 
 		if (SSIZE!=0)
 		{


### PR DESCRIPTION
This cherry-picks https://github.com/reicast/reicast-emulator/commit/34f46fb4822ea34bc1d1fc23b58d3604c24b39c3 from @flyinghead 