### PR TITLE
GL renderer optimizations for low-end devices

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -513,6 +513,7 @@ void InitSettings()
 	settings.rend.CustomTextures    = false;
 	settings.rend.DumpTextures      = false;
 	settings.rend.ScreenScaling     = 100;
+	settings.rend.Fog				= true;
 
 	settings.pvr.ta_skip			= 0;
 	settings.pvr.rend				= 0;
@@ -595,6 +596,7 @@ void LoadSettings(bool game_specific)
 	settings.rend.DumpTextures      = cfgLoadBool(config_section, "rend.DumpTextures", settings.rend.DumpTextures);
 	settings.rend.ScreenScaling     = cfgLoadInt(config_section, "rend.ScreenScaling", settings.rend.ScreenScaling);
 	settings.rend.ScreenScaling = min(max(1, settings.rend.ScreenScaling), 100);
+	settings.rend.Fog				= cfgLoadBool(config_section, "rend.Fog", settings.rend.Fog);
 
 	settings.pvr.ta_skip			= cfgLoadInt(config_section, "ta.skip", settings.pvr.ta_skip);
 	settings.pvr.rend				= cfgLoadInt(config_section, "pvr.rend", settings.pvr.rend);
@@ -718,6 +720,7 @@ void SaveSettings()
 	cfgSaveBool("config", "rend.CustomTextures", settings.rend.CustomTextures);
 	cfgSaveBool("config", "rend.DumpTextures", settings.rend.DumpTextures);
 	cfgSaveInt("config", "rend.ScreenScaling", settings.rend.ScreenScaling);
+	cfgSaveBool("config", "rend.Fog", settings.rend.Fog);
 	cfgSaveInt("config", "ta.skip", settings.pvr.ta_skip);
 	cfgSaveInt("config", "pvr.rend", settings.pvr.rend);
 

--- a/core/rend/gl4/gl4.h
+++ b/core/rend/gl4/gl4.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "rend/gles/gles.h"
-#include <map>
+#include <unordered_map>
 
 void gl4DrawStrips(GLuint output_fbo);
 
@@ -44,7 +44,7 @@ struct gl4_ctx
 		GLuint extra_depth_scale;
 	} modvol_shader;
 
-	std::map<int, gl4PipelineShader *> shaders;
+	std::unordered_map<u32, gl4PipelineShader> shaders;
 
 	struct
 	{
@@ -53,16 +53,6 @@ struct gl4_ctx
 		GLuint modvol_vao;
 		GLuint tr_poly_params;
 	} vbo;
-
-	gl4PipelineShader *getShader(int programId) {
-		gl4PipelineShader *shader = shaders[programId];
-		if (shader == NULL) {
-			shader = new gl4PipelineShader();
-			shaders[programId] = shader;
-			shader->program = -1;
-		}
-		return shader;
-	}
 };
 
 extern gl4_ctx gl4;

--- a/core/rend/gl4/gldraw.cpp
+++ b/core/rend/gl4/gldraw.cpp
@@ -153,6 +153,8 @@ template <u32 Type, bool SortingEnabled>
 		bool two_volumes_mode = (gp->tsp1.full != -1) && Type != ListType_Translucent;
 		bool color_clamp = gp->tsp.ColorClamp && (pvrrc.fog_clamp_min != 0 || pvrrc.fog_clamp_max != 0xffffffff);
 
+		int fog_ctrl = settings.rend.Fog ? gp->tsp.FogCtrl : 2;
+
 		int depth_func = 0;
 		if (Type == ListType_Translucent)
 		{
@@ -169,7 +171,7 @@ template <u32 Type, bool SortingEnabled>
 				gp->tsp.IgnoreTexA,
 				gp->tsp.ShadInstr,
 				gp->pcw.Offset,
-				gp->tsp.FogCtrl,
+				fog_ctrl,
 				two_volumes_mode,
 				depth_func,
 				gp->pcw.Gouraud,

--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -489,9 +489,8 @@ static void gles_term(void)
 	glDeleteBuffers(1, &gl4.vbo.tr_poly_params);
 	for (auto it = gl4.shaders.begin(); it != gl4.shaders.end(); it++)
 	{
-		if (it->second->program != -1)
-			glDeleteProgram(it->second->program);
-		delete it->second;
+		if (it->second.program != 0)
+			glDeleteProgram(it->second.program);
 	}
 	gl4.shaders.clear();
 	glDeleteVertexArrays(1, &gl4.vbo.main_vao);

--- a/core/rend/gl4/gles.cpp
+++ b/core/rend/gl4/gles.cpp
@@ -703,7 +703,7 @@ static bool RenderFrame()
 	gl4ShaderUniforms.fog_clamp_max[2] = ((pvrrc.fog_clamp_max >> 0) & 0xFF) / 255.0f;
 	gl4ShaderUniforms.fog_clamp_max[3] = ((pvrrc.fog_clamp_max >> 24) & 0xFF) / 255.0f;
 	
-	if (fog_needs_update)
+	if (fog_needs_update && settings.rend.Fog)
 	{
 		fog_needs_update = false;
 		UpdateFogTexture((u8 *)FOG_TABLE, GL_TEXTURE5, GL_RED);

--- a/core/rend/gles/glcache.h
+++ b/core/rend/gles/glcache.h
@@ -179,7 +179,7 @@ public:
 	void DisableCache() { _disable_cache = true; }
 	void EnableCache()
 	{
-	   _disable_cache = true;
+	   _disable_cache = false;
 	   Reset();
 	}
 

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -173,6 +173,7 @@ __forceinline
 		ShaderUniforms.trilinear_alpha = 1.f;
 
 	bool color_clamp = gp->tsp.ColorClamp && (pvrrc.fog_clamp_min != 0 || pvrrc.fog_clamp_max != 0xffffffff);
+	int fog_ctrl = settings.rend.Fog ? gp->tsp.FogCtrl : 2;
 
 	CurrentShader = GetProgram(Type == ListType_Punch_Through ? 1 : 0,
 								  SetTileClip(gp->tileclip, -1) + 1,
@@ -181,7 +182,7 @@ __forceinline
 								  gp->tsp.IgnoreTexA,
 								  gp->tsp.ShadInstr,
 								  gp->pcw.Offset,
-								  gp->tsp.FogCtrl,
+								  fog_ctrl,
 								  gp->pcw.Gouraud,
 								  gp->tcw.PixelFmt == PixelBumpMap,
 								  color_clamp,

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -174,27 +174,23 @@ __forceinline
 
 	bool color_clamp = gp->tsp.ColorClamp && (pvrrc.fog_clamp_min != 0 || pvrrc.fog_clamp_max != 0xffffffff);
 
-	CurrentShader = &gl.pogram_table[
-									 GetProgramID(Type == ListType_Punch_Through ? 1 : 0,
-											 	  SetTileClip(gp->tileclip, -1) + 1,
-												  gp->pcw.Texture,
-												  gp->tsp.UseAlpha,
-												  gp->tsp.IgnoreTexA,
-												  gp->tsp.ShadInstr,
-												  gp->pcw.Offset,
-												  gp->tsp.FogCtrl,
-												  gp->pcw.Gouraud,
-												  gp->tcw.PixelFmt == PixelBumpMap,
-												  color_clamp,
-												  ShaderUniforms.trilinear_alpha != 1.f)];
+	CurrentShader = GetProgram(Type == ListType_Punch_Through ? 1 : 0,
+								  SetTileClip(gp->tileclip, -1) + 1,
+								  gp->pcw.Texture,
+								  gp->tsp.UseAlpha,
+								  gp->tsp.IgnoreTexA,
+								  gp->tsp.ShadInstr,
+								  gp->pcw.Offset,
+								  gp->tsp.FogCtrl,
+								  gp->pcw.Gouraud,
+								  gp->tcw.PixelFmt == PixelBumpMap,
+								  color_clamp,
+								  ShaderUniforms.trilinear_alpha != 1.f);
 	
-	if (CurrentShader->program == -1)
-		CompilePipelineShader(CurrentShader);
-	else
-	{
-		glcache.UseProgram(CurrentShader->program);
-		ShaderUniforms.Set(CurrentShader);
-	}
+	glcache.UseProgram(CurrentShader->program);
+	if (CurrentShader->trilinear_alpha != -1)
+		glUniform1f(CurrentShader->trilinear_alpha, ShaderUniforms.trilinear_alpha);
+
 	SetTileClip(gp->tileclip, CurrentShader->pp_ClipTest);
 
 	//This bit control which pixels are affected
@@ -1122,14 +1118,8 @@ static void DrawQuad(GLuint texId, float x, float y, float w, float h, float u0,
 
 	ShaderUniforms.trilinear_alpha = 1.0;
 
-	PipelineShader *shader = &gl.pogram_table[GetProgramID(0, 1, 1, 0, 1, 0, 0, 2, false, false, false, false)];
-	if (shader->program == -1)
-		CompilePipelineShader(shader);
-	else
-	{
-		glcache.UseProgram(shader->program);
-		ShaderUniforms.Set(shader);
-	}
+	PipelineShader *shader = GetProgram(0, 1, 1, 0, 1, 0, 0, 2, false, false, false, false);
+	glcache.UseProgram(shader->program);
 
 	glActiveTexture(GL_TEXTURE0);
 	glcache.BindTexture(GL_TEXTURE_2D, texId);

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -1727,7 +1727,7 @@ bool RenderFrame()
 	ShaderUniforms.fog_clamp_max[2] = ((pvrrc.fog_clamp_max >> 0) & 0xFF) / 255.0f;
 	ShaderUniforms.fog_clamp_max[3] = ((pvrrc.fog_clamp_max >> 24) & 0xFF) / 255.0f;
 	
-	if (fog_needs_update)
+	if (fog_needs_update && settings.rend.Fog)
 	{
 		fog_needs_update = false;
 		UpdateFogTexture((u8 *)FOG_TABLE, GL_TEXTURE1, gl.fog_image_format);

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -865,7 +865,7 @@ static void gles_term()
 	gl_free_osd_resources();
 	free_output_framebuffer();
 
-	memset(gl.pogram_table, 0, sizeof(gl.pogram_table));
+	gl.shaders.clear();
 	gl_term();
 }
 
@@ -1014,7 +1014,7 @@ GLuint gl_CompileAndLink(const char* VertexShader, const char* FragmentShader)
 	return program;
 }
 
-int GetProgramID(u32 cp_AlphaTest, u32 pp_ClipTestMode,
+PipelineShader *GetProgram(u32 cp_AlphaTest, u32 pp_ClipTestMode,
 							u32 pp_Texture, u32 pp_UseAlpha, u32 pp_IgnoreTexA, u32 pp_ShadInstr, u32 pp_Offset,
 							u32 pp_FogCtrl, bool pp_Gouraud, bool pp_BumpMap, bool fog_clamping, bool trilinear)
 {
@@ -1033,7 +1033,25 @@ int GetProgramID(u32 cp_AlphaTest, u32 pp_ClipTestMode,
 	rv<<=1; rv|=fog_clamping;
 	rv<<=1; rv|=trilinear;
 
-	return rv;
+	PipelineShader *shader = &gl.shaders[rv];
+	if (shader->program == 0)
+	{
+		shader->cp_AlphaTest = cp_AlphaTest;
+		shader->pp_ClipTestMode = pp_ClipTestMode-1;
+		shader->pp_Texture = pp_Texture;
+		shader->pp_UseAlpha = pp_UseAlpha;
+		shader->pp_IgnoreTexA = pp_IgnoreTexA;
+		shader->pp_ShadInstr = pp_ShadInstr;
+		shader->pp_Offset = pp_Offset;
+		shader->pp_FogCtrl = pp_FogCtrl;
+		shader->pp_Gouraud = pp_Gouraud;
+		shader->pp_BumpMap = pp_BumpMap;
+		shader->fog_clamping = fog_clamping;
+		shader->trilinear = trilinear;
+		CompilePipelineShader(shader);
+	}
+
+	return shader;
 }
 
 bool CompilePipelineShader(	PipelineShader* s)
@@ -1156,65 +1174,6 @@ bool gl_create_resources()
 	glGenBuffers(1, &gl.vbo.idxs);
 	glGenBuffers(1, &gl.vbo.idxs2);
 
-	memset(gl.pogram_table,0,sizeof(gl.pogram_table));
-
-	PipelineShader* dshader=0;
-	u32 compile=0;
-#define forl(name,max) for(u32 name=0;name<=max;name++)
-	forl(cp_AlphaTest,1)
-	{
-		forl(pp_ClipTestMode,2)
-		{
-			forl(pp_UseAlpha,1)
-			{
-				forl(pp_Texture,1)
-				{
-					forl(pp_FogCtrl,3)
-					{
-						forl(pp_IgnoreTexA,1)
-						{
-							forl(pp_ShadInstr,3)
-							{
-								forl(pp_Offset,1)
-								{
-									forl(pp_Gouraud,1)
-									{
-										forl(pp_BumpMap,1)
-										{
-											forl(fog_clamping,1)
-											{
-												forl(trilinear,1)
-												{
-													dshader=&gl.pogram_table[GetProgramID(cp_AlphaTest,pp_ClipTestMode,pp_Texture,pp_UseAlpha,pp_IgnoreTexA,
-																			pp_ShadInstr,pp_Offset,pp_FogCtrl, (bool)pp_Gouraud, (bool)pp_BumpMap, (bool)fog_clamping,
-																			(bool)trilinear)];
-
-														dshader->cp_AlphaTest = cp_AlphaTest;
-														dshader->pp_ClipTestMode = pp_ClipTestMode-1;
-														dshader->pp_Texture = pp_Texture;
-														dshader->pp_UseAlpha = pp_UseAlpha;
-														dshader->pp_IgnoreTexA = pp_IgnoreTexA;
-														dshader->pp_ShadInstr = pp_ShadInstr;
-														dshader->pp_Offset = pp_Offset;
-														dshader->pp_FogCtrl = pp_FogCtrl;
-														dshader->pp_Gouraud = pp_Gouraud;
-														dshader->pp_BumpMap = pp_BumpMap;
-														dshader->fog_clamping = fog_clamping;
-														dshader->trilinear = trilinear;
-														dshader->program = -1;
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	
 	char vshader[8192];
 	sprintf(vshader, VertexShaderSource, gl.glsl_version_header, gl.gl_version, 1);
 	char fshader[8192];
@@ -1782,16 +1741,12 @@ bool RenderFrame()
 
 	ShaderUniforms.PT_ALPHA=(PT_ALPHA_REF&0xFF)/255.0f;
 
-//	for (u32 i=0;i<sizeof(gl.pogram_table)/sizeof(gl.pogram_table[0]);i++)
-//	{
-//		PipelineShader* s=&gl.pogram_table[i];
-//		if (s->program == -1)
-//			continue;
-//
-//		glcache.UseProgram(s->program);
-//
-//		ShaderUniforms.Set(s);
-//	}
+	for (auto it : gl.shaders)
+	{
+		glcache.UseProgram(it.second.program);
+		ShaderUniforms.Set(&it.second);
+	}
+
 	//setup render target first
 	if (is_rtt)
 	{

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include "rend/rend.h"
 
 #if (defined(GLES) && !defined(TARGET_NACL32) && HOST_OS != OS_DARWIN && !defined(USE_SDL)) || defined(_ANDROID)
@@ -93,7 +94,8 @@ struct gl_ctx
 
 	} modvol_shader;
 
-	PipelineShader pogram_table[24576];
+	std::map<u32, PipelineShader> shaders;
+
 	struct
 	{
 		GLuint program;
@@ -176,7 +178,7 @@ void free_output_framebuffer();
 
 void HideOSD();
 void OSD_DRAW(bool clear_screen);
-int GetProgramID(u32 cp_AlphaTest, u32 pp_ClipTestMode,
+PipelineShader *GetProgram(u32 cp_AlphaTest, u32 pp_ClipTestMode,
 							u32 pp_Texture, u32 pp_UseAlpha, u32 pp_IgnoreTexA, u32 pp_ShadInstr, u32 pp_Offset,
 							u32 pp_FogCtrl, bool pp_Gouraud, bool pp_BumpMap, bool fog_clamping, bool trilinear);
 
@@ -223,9 +225,6 @@ extern struct ShaderUniforms_t
 		if (s->sp_FOG_COL_VERT!=-1)
 			glUniform3fv( s->sp_FOG_COL_VERT, 1, ps_FOG_COL_VERT);
 
-		if (s->trilinear_alpha != -1)
-			glUniform1f(s->trilinear_alpha, trilinear_alpha);
-		
 		if (s->fog_clamp_min != -1)
 			glUniform4fv(s->fog_clamp_min, 1, fog_clamp_min);
 		if (s->fog_clamp_max != -1)

--- a/core/rend/gles/gles.h
+++ b/core/rend/gles/gles.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <map>
+#include <unordered_map>
 #include "rend/rend.h"
 
 #if (defined(GLES) && !defined(TARGET_NACL32) && HOST_OS != OS_DARWIN && !defined(USE_SDL)) || defined(_ANDROID)
@@ -94,7 +94,7 @@ struct gl_ctx
 
 	} modvol_shader;
 
-	std::map<u32, PipelineShader> shaders;
+	std::unordered_map<u32, PipelineShader> shaders;
 
 	struct
 	{

--- a/core/rend/gles/imgui_impl_opengl3.cpp
+++ b/core/rend/gles/imgui_impl_opengl3.cpp
@@ -67,6 +67,7 @@
 #endif
 
 #include "gles.h"
+#include "glcache.h"
 
 // OpenGL Data
 static char         g_GlslVersionString[32] = "";
@@ -588,11 +589,10 @@ void ImGui_ImplOpenGL3_DrawBackground()
 
 ImTextureID ImGui_ImplOpenGL3_CreateVmuTexture(const unsigned int *data)
 {
-	GLuint tex_id;
-    glGenTextures(1, &tex_id);
-    glBindTexture(GL_TEXTURE_2D, tex_id);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	GLuint tex_id = glcache.GenTexture();
+    glcache.BindTexture(GL_TEXTURE_2D, tex_id);
+    glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 48, 32, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
     return reinterpret_cast<ImTextureID>(tex_id);
@@ -600,5 +600,5 @@ ImTextureID ImGui_ImplOpenGL3_CreateVmuTexture(const unsigned int *data)
 
 void ImGui_ImplOpenGL3_DeleteVmuTexture(ImTextureID tex_id)
 {
-	glDeleteTextures(1, &(GLuint &)tex_id);
+	glcache.DeleteTextures(1, &(GLuint &)tex_id);
 }

--- a/core/rend/gles/imgui_impl_opengl3.cpp
+++ b/core/rend/gles/imgui_impl_opengl3.cpp
@@ -128,28 +128,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
     draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
     // Backup GL state
-    GLenum last_active_texture; glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint*)&last_active_texture);
     glActiveTexture(GL_TEXTURE0);
-    GLint last_program; glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
-    GLint last_texture; glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
-    GLint last_sampler; glGetIntegerv(GL_SAMPLER_BINDING, &last_sampler);
-    GLint last_array_buffer; glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
-    GLint last_vertex_array; glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
-#ifdef GL_POLYGON_MODE
-    GLint last_polygon_mode[2]; glGetIntegerv(GL_POLYGON_MODE, last_polygon_mode);
-#endif
-    GLint last_viewport[4]; glGetIntegerv(GL_VIEWPORT, last_viewport);
-    GLint last_scissor_box[4]; glGetIntegerv(GL_SCISSOR_BOX, last_scissor_box);
-    GLenum last_blend_src_rgb; glGetIntegerv(GL_BLEND_SRC_RGB, (GLint*)&last_blend_src_rgb);
-    GLenum last_blend_dst_rgb; glGetIntegerv(GL_BLEND_DST_RGB, (GLint*)&last_blend_dst_rgb);
-    GLenum last_blend_src_alpha; glGetIntegerv(GL_BLEND_SRC_ALPHA, (GLint*)&last_blend_src_alpha);
-    GLenum last_blend_dst_alpha; glGetIntegerv(GL_BLEND_DST_ALPHA, (GLint*)&last_blend_dst_alpha);
-    GLenum last_blend_equation_rgb; glGetIntegerv(GL_BLEND_EQUATION_RGB, (GLint*)&last_blend_equation_rgb);
-    GLenum last_blend_equation_alpha; glGetIntegerv(GL_BLEND_EQUATION_ALPHA, (GLint*)&last_blend_equation_alpha);
-    GLboolean last_enable_blend = glIsEnabled(GL_BLEND);
-    GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
-    GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);
-    GLboolean last_enable_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
     bool clip_origin_lower_left = true;
 #ifdef GL_CLIP_ORIGIN
     if (gl.gl_major >= 4 && glClipControl != NULL)
@@ -167,13 +146,13 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
 
 		// (Re-)create the background texture and reserve space for it
 		if (g_BackgroundTexture != 0)
-	    	glDeleteTextures(1, &g_BackgroundTexture);
-		glGenTextures(1, &g_BackgroundTexture);
-		glBindTexture(GL_TEXTURE_2D, g_BackgroundTexture);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			glcache.DeleteTextures(1, &g_BackgroundTexture);
+		g_BackgroundTexture = glcache.GenTexture();
+		glcache.BindTexture(GL_TEXTURE_2D, g_BackgroundTexture);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, fb_width, fb_height, 0, GL_RGB, GL_UNSIGNED_BYTE, (GLvoid*)NULL);
 
 		// Copy the current framebuffer into it
@@ -181,12 +160,12 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
     }
 
     // Setup render state: alpha-blending enabled, no face culling, no depth testing, scissor enabled, polygon fill
-    glEnable(GL_BLEND);
+    glcache.Enable(GL_BLEND);
     glBlendEquation(GL_FUNC_ADD);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glDisable(GL_CULL_FACE);
-    glDisable(GL_DEPTH_TEST);
-    glEnable(GL_SCISSOR_TEST);
+    glcache.BlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glcache.Disable(GL_CULL_FACE);
+    glcache.Disable(GL_DEPTH_TEST);
+    glcache.Enable(GL_SCISSOR_TEST);
 #ifdef GL_POLYGON_MODE
     if (glPolygonMode != NULL)
     	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -206,7 +185,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
         { 0.0f,         0.0f,        -1.0f,   0.0f },
         { (R+L)/(L-R),  (T+B)/(B-T),  0.0f,   1.0f },
     };
-    glUseProgram(g_ShaderHandle);
+    glcache.UseProgram(g_ShaderHandle);
     glUniform1i(g_AttribLocationTex, 0);
     glUniformMatrix4fv(g_AttribLocationProjMtx, 1, GL_FALSE, &ortho_projection[0][0]);
     if (gl.gl_major >= 3 && glBindSampler != NULL)
@@ -261,7 +240,7 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
                         glScissor((int)clip_rect.x, (int)clip_rect.y, (int)clip_rect.z, (int)clip_rect.w); // Support for GL 4.5's glClipControl(GL_UPPER_LEFT)
 
                     // Bind texture, Draw
-                    glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->TextureId);
+                    glcache.BindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->TextureId);
                     glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, idx_buffer_offset);
                 }
             }
@@ -270,28 +249,6 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
     }
     if (vao_handle != 0)
     	glDeleteVertexArrays(1, &vao_handle);
-
-    // Restore modified GL state
-    glUseProgram(last_program);
-    glBindTexture(GL_TEXTURE_2D, last_texture);
-    if (gl.gl_major >= 3 && glBindSampler != NULL)
-    	glBindSampler(0, last_sampler);
-    glActiveTexture(last_active_texture);
-    glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
-    if (gl.gl_major >= 3)
-    	glBindVertexArray(last_vertex_array);
-    glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha);
-    glBlendFuncSeparate(last_blend_src_rgb, last_blend_dst_rgb, last_blend_src_alpha, last_blend_dst_alpha);
-    if (last_enable_blend) glEnable(GL_BLEND); else glDisable(GL_BLEND);
-    if (last_enable_cull_face) glEnable(GL_CULL_FACE); else glDisable(GL_CULL_FACE);
-    if (last_enable_depth_test) glEnable(GL_DEPTH_TEST); else glDisable(GL_DEPTH_TEST);
-    if (last_enable_scissor_test) glEnable(GL_SCISSOR_TEST); else glDisable(GL_SCISSOR_TEST);
-#ifdef GL_POLYGON_MODE
-    if (glPolygonMode != NULL)
-    	glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
-#endif
-    glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2], (GLsizei)last_viewport[3]);
-    glScissor(last_scissor_box[0], last_scissor_box[1], (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
 }
 
 bool ImGui_ImplOpenGL3_CreateFontsTexture()
@@ -303,20 +260,15 @@ bool ImGui_ImplOpenGL3_CreateFontsTexture()
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bits (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
 
     // Upload texture to graphics system
-    GLint last_texture;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
-    glGenTextures(1, &g_FontTexture);
-    glBindTexture(GL_TEXTURE_2D, g_FontTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    g_FontTexture = glcache.GenTexture();
+    glcache.BindTexture(GL_TEXTURE_2D, g_FontTexture);
+    glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glcache.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
 
     // Store our identifier
     io.Fonts->TexID = (ImTextureID)(intptr_t)g_FontTexture;
-
-    // Restore state
-    glBindTexture(GL_TEXTURE_2D, last_texture);
 
     return true;
 }
@@ -326,7 +278,7 @@ void ImGui_ImplOpenGL3_DestroyFontsTexture()
     if (g_FontTexture)
     {
         ImGuiIO& io = ImGui::GetIO();
-        glDeleteTextures(1, &g_FontTexture);
+        glcache.DeleteTextures(1, &g_FontTexture);
         io.Fonts->TexID = 0;
         g_FontTexture = 0;
     }
@@ -370,12 +322,6 @@ static bool CheckProgram(GLuint handle, const char* desc)
 
 bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
 {
-    // Backup GL state
-    GLint last_texture, last_array_buffer, last_vertex_array;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
-    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
-    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
-
     // Parse GLSL version string
     int glsl_version = 130;
     sscanf(g_GlslVersionString, "#version %d", &glsl_version);
@@ -535,12 +481,6 @@ bool    ImGui_ImplOpenGL3_CreateDeviceObjects()
 
     ImGui_ImplOpenGL3_CreateFontsTexture();
 
-    // Restore modified GL state
-    glBindTexture(GL_TEXTURE_2D, last_texture);
-    glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
-    if (gl.gl_major >= 3)
-    	glBindVertexArray(last_vertex_array);
-
     return true;
 }
 
@@ -564,7 +504,7 @@ void ImGui_ImplOpenGL3_DestroyDeviceObjects()
     ImGui_ImplOpenGL3_DestroyFontsTexture();
 
     if (g_BackgroundTexture != 0)
-    	glDeleteTextures(1, &g_BackgroundTexture);
+    	glcache.DeleteTextures(1, &g_BackgroundTexture);
     g_BackgroundTexture = 0;
 }
 
@@ -582,7 +522,7 @@ void ImGui_ImplOpenGL3_DrawBackground()
 	}
 	else
 	{
-		glClearColor(0, 0, 0, 0);
+		glcache.ClearColor(0, 0, 0, 0);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}
 }

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1408,24 +1408,6 @@ void gui_display_ui()
 		gui_state = Closed;
 }
 
-void gui_display_fps(const char *string)
-{
-	ImGui_Impl_NewFrame();
-    ImGui::NewFrame();
-
-    ImGui::SetNextWindowBgAlpha(0);
-    ImGui::SetNextWindowPos(ImVec2(0, screen_height), ImGuiCond_Always, ImVec2(0.f, 1.f));	// Lower left corner
-
-    ImGui::Begin("##fps", NULL, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoNav
-    		| ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoBackground);
-    ImGui::SetWindowFontScale(2);
-    ImGui::TextColored(ImVec4(1, 1, 0, 0.7), "%s", string);
-    ImGui::End();
-
-    ImGui::Render();
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-}
-
 static float LastFPSTime;
 static int lastFrameCount = 0;
 static float fps = -1;

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -940,6 +940,9 @@ static void gui_display_settings()
 		    	ImGui::Checkbox("Shadows", &settings.rend.ModifierVolumes);
 	            ImGui::SameLine();
 	            ShowHelpMarker("Enable modifier volumes, usually used for shadows");
+		    	ImGui::Checkbox("Fog", &settings.rend.Fog);
+	            ImGui::SameLine();
+	            ShowHelpMarker("Enable fog effects");
 		    	ImGui::Checkbox("Widescreen", &settings.rend.WideScreen);
 	            ImGui::SameLine();
 	            ShowHelpMarker("Draw geometry outside of the normal 4:3 aspect ratio. May produce graphical glitches in the revealed areas");

--- a/core/types.h
+++ b/core/types.h
@@ -633,6 +633,7 @@ struct settings_t
 		bool CustomTextures;
 		bool DumpTextures;
 		int ScreenScaling;	// in percent. 50 means half the native resolution
+		bool Fog;
 	} rend;
 
 	struct


### PR DESCRIPTION
New option to disable fog effects
Fix GL state cache that was always disabled
put all shaders in a map and set uniforms once each frame
Use the GL cache in imgui, avoid saving/restoring state
