### PR TITLE
Android: remove duplicate intent filters

### DIFF
--- a/shell/android-studio/reicast/src/dreamcast/AndroidManifest.xml
+++ b/shell/android-studio/reicast/src/dreamcast/AndroidManifest.xml
@@ -3,55 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <application android:name="com.reicast.emulator.Emulator">
 	    <activity
-		    android:name="com.reicast.emulator.NativeGLActivity">
-		    <intent-filter>
-		        <action android:name="android.intent.action.VIEW" />
-		
-		        <category android:name="android.intent.category.DEFAULT" />
-		        <category android:name="android.intent.category.BROWSABLE" />
-		
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.GDI"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.gdi"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.CHD"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.chd"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.CDI"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.cdi"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.CUE"
-		            android:scheme="file" />
-		        <data
-		            android:host="*"
-		            android:mimeType="*/*"
-		            android:pathPattern=".*\\.cue"
-		            android:scheme="file" />
-		    </intent-filter>
-		</activity>
+		    android:name="com.reicast.emulator.NativeGLActivity"/>
 		<activity-alias
 			android:name="com.reicast.emulator.MainActivity"
 			android:targetActivity="com.reicast.emulator.NativeGLActivity">

--- a/shell/android-studio/reicast/src/main/AndroidManifest.xml
+++ b/shell/android-studio/reicast/src/main/AndroidManifest.xml
@@ -53,14 +53,8 @@
         <activity
             android:name="com.reicast.emulator.NativeGLActivity"
             android:configChanges="orientation|navigation|screenSize|screenLayout|uiMode|keyboard|keyboardHidden"
-            android:screenOrientation="sensorLandscape">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="tv.ouya.intent.category.GAME" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:screenOrientation="sensorLandscape"
+            android:exported="true"/>
         <activity-alias
             android:name="com.reicast.emulator.MainActivity"
             android:targetActivity="com.reicast.emulator.NativeGLActivity">

--- a/shell/android-studio/reicast/src/naomi/AndroidManifest.xml
+++ b/shell/android-studio/reicast/src/naomi/AndroidManifest.xml
@@ -3,65 +3,7 @@
         android:name="com.reicast.emulator.Emulator">
 
         <activity
-            android:name="com.reicast.emulator.NativeGLActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.LST"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.lst"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.BIN"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.bin"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.DAT"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.dat"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.ZIP"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.zip"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.7Z"
-                    android:scheme="file" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.7z"
-                    android:scheme="file" />
-            </intent-filter>
-        </activity>
+            android:name="com.reicast.emulator.NativeGLActivity"/>
         <activity-alias
             android:name="com.reicast.emulator.MainActivity"
             android:targetActivity="com.reicast.emulator.NativeGLActivity">


### PR DESCRIPTION
The latest reicast builds displayed a redundant second launcher icon in the app drawer, due to a change in #1548.  This fixes the issue by removing the duplicate intent filters causing the redundant icon to display.