### PR TITLE
AUDIO: Allow backend specific settings

### DIFF
--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -721,6 +721,26 @@ void SaveSettings()
 	cfgSaveBool("config", "aica.NoBatch", settings.aica.NoBatch);
 	cfgSaveBool("config", "aica.NoSound", settings.aica.NoSound);
 	cfgSaveStr("audio", "backend", settings.audio.backend.c_str());
+
+	// Write backend specific settings
+	// std::map<std::string, std::map<std::string, std::string>>
+	for (std::map<std::string, std::map<std::string, std::string>>::iterator it = settings.audio.options.begin(); it != settings.audio.options.end(); ++it)
+	{
+
+		std::pair<std::string, std::map<std::string, std::string>> p = (std::pair<std::string, std::map<std::string, std::string>>)*it;
+		std::string section = p.first;
+		std::map<std::string, std::string> options = p.second;
+
+		for (std::map<std::string, std::string>::iterator it2 = options.begin(); it2 != options.end(); ++it2)
+		{
+			std::pair<std::string, std::string> p2 = (std::pair<std::string, std::string>)*it2;
+			std::string key = p2.first;
+			std::string val = p2.second;
+
+			cfgSaveStr(section.c_str(), key.c_str(), val.c_str());
+		}
+	}
+
 	cfgSaveBool("config", "rend.WideScreen", settings.rend.WideScreen);
 	cfgSaveBool("config", "rend.ShowFPS", settings.rend.ShowFPS);
 	if (!rtt_to_buffer_game || !settings.rend.RenderToTextureBuffer)

--- a/core/oslib/audiobackend_alsa.cpp
+++ b/core/oslib/audiobackend_alsa.cpp
@@ -62,7 +62,7 @@ static void alsa_init()
 
 	if (rc < 0)
 	{
-		fprintf(stderr, "unable to open PCM device %s: %s\n", device.c_str(), snd_strerror(rc));
+		fprintf(stderr, "ALSA: unable to open PCM device %s: %s\n", device.c_str(), snd_strerror(rc));
 		return;
 	}
 
@@ -75,7 +75,7 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_any(handle, params);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_any %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_any %s\n", snd_strerror(rc));
 		return;
 	}
 
@@ -85,7 +85,7 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_set_access(handle, params, SND_PCM_ACCESS_RW_INTERLEAVED);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_access %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_access %s\n", snd_strerror(rc));
 		return;
 	}
 
@@ -93,7 +93,7 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_S16_LE);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_format %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_format %s\n", snd_strerror(rc));
 		return;
 	}
 
@@ -101,7 +101,7 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_set_channels(handle, params, 2);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_channels %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_channels %s\n", snd_strerror(rc));
 		return;
 	}
 
@@ -110,7 +110,7 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_set_rate_near(handle, params, &val, &dir);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_rate_near %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_rate_near %s\n", snd_strerror(rc));
 		return;
 	}
 
@@ -119,26 +119,31 @@ static void alsa_init()
 	rc=snd_pcm_hw_params_set_period_size_near(handle, params, &period_size, &dir);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_buffer_size_near %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_buffer_size_near %s\n", snd_strerror(rc));
 		return;
 	}
 	else
+	{
 		printf("ALSA: period size set to %ld\n", period_size);
+	}
+
 	buffer_size = (44100 * 100 /* settings.omx.Audio_Latency */ / 1000 / period_size + 1) * period_size;
 	rc=snd_pcm_hw_params_set_buffer_size_near(handle, params, &buffer_size);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Error:snd_pcm_hw_params_set_buffer_size_near %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Error:snd_pcm_hw_params_set_buffer_size_near %s\n", snd_strerror(rc));
 		return;
 	}
 	else
+	{
 		printf("ALSA: buffer size set to %ld\n", buffer_size);
+	}
 
 	/* Write the parameters to the driver */
 	rc = snd_pcm_hw_params(handle, params);
 	if (rc < 0)
 	{
-		fprintf(stderr, "Unable to set hw parameters: %s\n", snd_strerror(rc));
+		fprintf(stderr, "ALSA: Unable to set hw parameters: %s\n", snd_strerror(rc));
 		return;
 	}
 }

--- a/core/oslib/audiobackend_coreaudio.cpp
+++ b/core/oslib/audiobackend_coreaudio.cpp
@@ -159,7 +159,8 @@ audiobackend_t audiobackend_coreaudio = {
     "Core Audio", // Name
     &coreaudio_init,
     &coreaudio_push,
-    &coreaudio_term
+    &coreaudio_term,
+	NULL
 };
 
 static bool core = RegisterAudioBackend(&audiobackend_coreaudio);

--- a/core/oslib/audiobackend_directsound.cpp
+++ b/core/oslib/audiobackend_directsound.cpp
@@ -185,7 +185,8 @@ audiobackend_t audiobackend_directsound = {
     "Microsoft DirectSound", // Name
     &directsound_init,
     &directsound_push,
-    &directsound_term
+    &directsound_term,
+	NULL
 };
 
 static bool ds = RegisterAudioBackend(&audiobackend_directsound);

--- a/core/oslib/audiobackend_libao.cpp
+++ b/core/oslib/audiobackend_libao.cpp
@@ -43,7 +43,8 @@ audiobackend_t audiobackend_libao = {
 		"libao", // Name
 		&libao_init,
 		&libao_push,
-		&libao_term
+		&libao_term,
+		NULL
 };
 
 static bool ao = RegisterAudioBackend(&audiobackend_libao);

--- a/core/oslib/audiobackend_omx.cpp
+++ b/core/oslib/audiobackend_omx.cpp
@@ -313,7 +313,8 @@ audiobackend_t audiobackend_omx = {
     "OpenMAX IL", // Name
     &omx_init,
     &omx_push,
-    &omx_term
+    &omx_term,
+	NULL
 };
 
 static bool omx = RegisterAudioBackend(&audiobackend_omx);

--- a/core/oslib/audiobackend_oss.cpp
+++ b/core/oslib/audiobackend_oss.cpp
@@ -48,7 +48,8 @@ audiobackend_t audiobackend_oss = {
 		"Open Sound System", // Name
 		&oss_init,
 		&oss_push,
-		&oss_term
+		&oss_term,
+		NULL
 };
 
 static bool oss = RegisterAudioBackend(&audiobackend_oss);

--- a/core/oslib/audiobackend_pulseaudio.cpp
+++ b/core/oslib/audiobackend_pulseaudio.cpp
@@ -43,7 +43,8 @@ audiobackend_t audiobackend_pulseaudio = {
 		"PulseAudio", // Name
 		&pulseaudio_init,
 		&pulseaudio_push,
-		&pulseaudio_term
+		&pulseaudio_term,
+		NULL
 };
 
 static bool pulse = RegisterAudioBackend(&audiobackend_pulseaudio);

--- a/core/oslib/audiostream.h
+++ b/core/oslib/audiostream.h
@@ -11,6 +11,29 @@ u32 asRingFreeCount();
 bool asRingRead(u8* dst,u32 count=0);
 void UpdateBuff(u8* pos);
 
+typedef std::vector<std::string> (*audio_option_callback_t)();
+enum audio_option_type
+{
+	text = 0
+,	integer = 1
+,	list = 2
+};
+
+typedef struct {
+	std::string cfg_name;
+	std::string caption;
+	audio_option_type type;
+
+	// type int_value (spin edit)
+	int min_value;
+	int max_value;
+
+	// type list edit (string/char*)
+	audio_option_callback_t list_callback;
+} audio_option_t;
+
+typedef audio_option_t* (*audio_options_func_t)(int* option_count);
+
 typedef void (*audio_backend_init_func_t)();
 typedef u32 (*audio_backend_push_func_t)(void*, u32, bool);
 typedef void (*audio_backend_term_func_t)();
@@ -20,6 +43,7 @@ typedef struct {
     audio_backend_init_func_t init;
     audio_backend_push_func_t push;
     audio_backend_term_func_t term;
+	audio_options_func_t get_options;
 } audiobackend_t;
 extern bool RegisterAudioBackend(audiobackend_t* backend);
 extern void InitAudio();

--- a/core/oslib/audiostream.h
+++ b/core/oslib/audiostream.h
@@ -14,8 +14,8 @@ void UpdateBuff(u8* pos);
 typedef std::vector<std::string> (*audio_option_callback_t)();
 enum audio_option_type
 {
-	text = 0
-,	integer = 1
+	integer = 0
+,	checkbox = 1
 ,	list = 2
 };
 

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1026,6 +1026,13 @@ static void gui_display_settings()
             ImGui::SameLine();
             ShowHelpMarker("Disable the emulator sound output");
 
+			ImGui::Checkbox("Enable DSP", &settings.aica.NoBatch);
+            ImGui::SameLine();
+            ShowHelpMarker("Enable the Dreamcast Digital Sound Processor. Only recommended on fast and arm64 platforms");
+			ImGui::Checkbox("Limit FPS", &settings.aica.LimitFPS);
+            ImGui::SameLine();
+            ShowHelpMarker("Use the sound output to limit the speed of the emulator. Recommended in most cases");
+
 			audiobackend_t* backend = NULL;;
 			std::string backend_name = settings.audio.backend;
 			if (backend_name != "auto" && backend_name != "none")
@@ -1118,12 +1125,6 @@ static void gui_display_settings()
 				}
 			}
 
-			ImGui::Checkbox("Enable DSP", &settings.aica.NoBatch);
-            ImGui::SameLine();
-            ShowHelpMarker("Enable the Dreamcast Digital Sound Processor. Only recommended on fast and arm64 platforms");
-			ImGui::Checkbox("Limit FPS", &settings.aica.LimitFPS);
-            ImGui::SameLine();
-            ShowHelpMarker("Use the sound output to limit the speed of the emulator. Recommended in most cases");
 			ImGui::PopStyleVar();
 			ImGui::EndTabItem();
 		}

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1099,7 +1099,20 @@ static void gui_display_settings()
 					}
 					value = (*cfg_entries)[options->cfg_name];
 
-					if (options->type == list)
+					if (options->type == integer)
+					{
+						int val = stoi(value);
+						ImGui::SliderInt(options->caption.c_str(), &val, options->min_value, options->max_value);
+						(*cfg_entries)[options->cfg_name] = to_string(val);
+					}
+					else if (options->type == checkbox)
+					{
+						bool check = (value == "1");
+						ImGui::Checkbox(options->caption.c_str(), &check);
+						std::string cur = check ? "1" : "0";
+						(*cfg_entries)[options->cfg_name] = cur;
+					}
+					else if (options->type == list)
 					{
 						if (ImGui::BeginCombo(options->caption.c_str(), value.c_str(), ImGuiComboFlags_None))
 						{
@@ -1119,6 +1132,9 @@ static void gui_display_settings()
 							}
 							ImGui::EndCombo();
 						}
+					}
+					else {
+						printf("Unknown option\n");
 					}
 
 					options++;

--- a/core/types.h
+++ b/core/types.h
@@ -344,6 +344,7 @@ int darw_printf(const wchar* Text,...);
 //includes from c++rt
 #include <vector>
 #include <string>
+#include <map>
 using namespace std;
 
 //used for asm-olny functions
@@ -387,7 +388,7 @@ using namespace std;
 #ifndef RELEASE
 #define EMUERROR(format, ...) printf("Error in %20s:%s:%d: " format "\n", \
 		__FILE__, __FUNCTION__, __LINE__, ##__VA_ARGS__)
-//strlen(__FILE__) <= 20 ? __FILE__ : __FILE__ + strlen(__FILE__) - 20, 
+//strlen(__FILE__) <= 20 ? __FILE__ : __FILE__ + strlen(__FILE__) - 20,
 #else
 #define EMUERROR(format, ...)
 #endif
@@ -681,7 +682,12 @@ struct settings_t
 
 	struct{
 		std::string backend;
+
+		// slug<<key, value>>
+		std::map<std::string, std::map<std::string, std::string>> options;
 	} audio;
+
+
 #if USE_OMX
 	struct
 	{

--- a/shell/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -547,7 +547,8 @@ audiobackend_t audiobackend_android = {
         "Android Audio", // Name
         &androidaudio_init,
         &androidaudio_push,
-        &androidaudio_term
+        &androidaudio_term,
+        NULL
 };
 
 static bool android = RegisterAudioBackend(&audiobackend_android);


### PR DESCRIPTION
The settings can be defined by each audio backend (currently only alsa is implemented) and of different types (integer with min and max value, checkbox and a list with a callback).

I think this is now ready for the moment as any further work can be done by subsequent prs.

![alsa device list](https://user-images.githubusercontent.com/15894566/57097710-b8e26c00-6d18-11e9-955f-4f11350aff6d.png)