### PR TITLE
Fix small issues for mingw builds on Linux

### DIFF
--- a/core/imgread/ioctl.cpp
+++ b/core/imgread/ioctl.cpp
@@ -4,7 +4,7 @@
 #include "common.h"
 
 #include <stddef.h>
-#include <Windows.h>
+#include <windows.h>
 
 #include <ntddscsi.h>
 #include "SCSIDEFS.H"

--- a/core/rend/d3d11/d3d11.cpp
+++ b/core/rend/d3d11/d3d11.cpp
@@ -1,6 +1,6 @@
 #include <d3d11.h>
-#include "hw\pvr\Renderer_if.h"
-#include "oslib\oslib.h"
+#include "hw/pvr/Renderer_if.h"
+#include "oslib/oslib.h"
 
 #pragma comment(lib,"d3d11.lib")
 

--- a/core/rend/gles/gles.cpp
+++ b/core/rend/gles/gles.cpp
@@ -783,7 +783,7 @@ GLuint fogTextureId;
 
 		return rv;
 	}
-	#include <Wingdi.h>
+	#include <wingdi.h>
 	void gl_swap()
 	{
 		wglSwapLayerBuffers(ourWindowHandleToDeviceContext,WGL_SWAP_MAIN_PLANE);

--- a/core/stdclass.h
+++ b/core/stdclass.h
@@ -7,7 +7,7 @@
 #if HOST_OS!=OS_WINDOWS
 #include <pthread.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -1,6 +1,6 @@
-#include "oslib\oslib.h"
-#include "oslib\audiostream.h"
-#include "imgread\common.h"
+#include "oslib/oslib.h"
+#include "oslib/audiostream.h"
+#include "imgread/common.h"
 #include "stdclass.h"
 #include "cfg/cfg.h"
 #include "xinput_gamepad.h"
@@ -10,8 +10,8 @@
 #include <windows.h>
 #include <windowsx.h>
 
-#include <Xinput.h>
-#include "hw\maple\maple_cfg.h"
+#include <xinput.h>
+#include "hw/maple/maple_cfg.h"
 #pragma comment(lib, "XInput9_1_0.lib")
 
 PCHAR*

--- a/core/windows/xinput_gamepad.h
+++ b/core/windows/xinput_gamepad.h
@@ -1,4 +1,4 @@
-#include <Xinput.h>
+#include <xinput.h>
 #include "input/gamepad_device.h"
 #include "rend/gui.h"
 

--- a/shell/linux/Makefile
+++ b/shell/linux/Makefile
@@ -18,6 +18,7 @@ CC=${CC_PREFIX}gcc
 AS=${CC_PREFIX}as
 STRIP=${CC_PREFIX}strip
 LD=${CC}
+WINDRES=${CC_PREFIX}windres
 CHD5_LZMA := 1
 CHD5_FLAC := 1
 
@@ -432,7 +433,7 @@ OBJECTS:=$(patsubst $(RZDCY_SRC_DIR)/%,$(BUILDDIR)/%,$(OBJECTS))
 ifdef FOR_WINDOWS
 OBJECTS+=$(BUILDDIR)/reicastres.build_obj
 $(BUILDDIR)/reicastres.build_obj: $(LOCAL_PATH)/../windows/reicast.rc $(LOCAL_PATH)/../windows/reicast.ico $(RZDCY_SRC_DIR)/version.h
-	windres $< $@
+	$(WINDRES) $< $@
 endif
 
 DEPDIR := .dep-$(BUILDDIR)


### PR DESCRIPTION
Doenst like the paths, big surprise. I tipically build it like:

  make platform=win32 CXX=x86_64-w64-mingw32-g++ \
       WINDRES=x86_64-w64-mingw32-windres \
       CC=x86_64-w64-mingw32-gcc