### PR TITLE
vmem API consolidation and implementation of NO_RWX

### DIFF
--- a/core/build.h
+++ b/core/build.h
@@ -148,7 +148,7 @@
 #define CPU_GENERIC  0x20000005 //used for pnacl, emscripten, etc
 #define CPU_PPC      0x20000006
 #define CPU_PPC64    0x20000007
-#define CPU_A64      0x20000008
+#define CPU_ARM64    0x20000008
 #define CPU_MIPS64   0x20000009
 
 //BUILD_COMPILER
@@ -325,6 +325,13 @@
 #define ATTR_UNUSED
 #endif
 
+
+// Some restrictions on FEAT_NO_RWX_PAGES
+#if defined(FEAT_NO_RWX_PAGES) && FEAT_SHREC == DYNAREC_JIT
+#if HOST_CPU != CPU_X64 && HOST_CPU != CPU_ARM64
+#error "FEAT_NO_RWX_PAGES Only implemented for X64 and ARMv8"
+#endif
+#endif
 
 
 // TARGET PLATFORM

--- a/core/hw/aica/dsp_arm64.cpp
+++ b/core/hw/aica/dsp_arm64.cpp
@@ -27,7 +27,7 @@
 #include "deps/vixl/aarch64/macro-assembler-aarch64.h"
 using namespace vixl::aarch64;
 
-extern void Arm64CacheFlush(void* start, void* end);
+extern void vmem_platform_flush_cache(void *icache_start, void *icache_end, void *dcache_start, void *dcache_end);
 
 class DSPAssembler : public MacroAssembler
 {
@@ -54,9 +54,9 @@ public:
 			Stp(xzr, xzr, MemOperand(x0, 48));
 			Ret();
 			FinalizeCode();
-#ifdef _ANDROID
-			Arm64CacheFlush(GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>());
-#endif
+			vmem_platform_flush_cache(
+				GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>(),
+				GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>());
 
 			return;
 		}
@@ -387,9 +387,9 @@ public:
 #endif
 		FinalizeCode();
 
-#ifdef _ANDROID
-		Arm64CacheFlush(GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>());
-#endif
+		vmem_platform_flush_cache(
+			GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>(),
+			GetBuffer()->GetStartAddress<void*>(), GetBuffer()->GetEndAddress<void*>());
 	}
 
 private:

--- a/core/hw/arm7/arm64.cpp
+++ b/core/hw/arm7/arm64.cpp
@@ -28,7 +28,7 @@
 using namespace vixl::aarch64;
 //#include "deps/vixl/aarch32/disasm-aarch32.h"
 
-extern void Arm64CacheFlush(void* start, void* end);
+extern void vmem_platform_flush_cache(void *icache_start, void *icache_end, void *dcache_start, void *dcache_end);
 extern u32 arm_single_op(u32 opcode);
 extern "C" void arm_dispatch();
 extern "C" void arm_exit();
@@ -41,7 +41,7 @@ extern reg_pair arm_Reg[RN_ARM_REG_COUNT];
 MacroAssembler *assembler;
 
 extern "C" void armFlushICache(void *bgn, void *end) {
-	Arm64CacheFlush(bgn, end);
+	vmem_platform_flush_cache(bgn, end, bgn, end);
 }
 
 static MemOperand arm_reg_operand(u32 regn)
@@ -143,7 +143,9 @@ void armv_end(void* codestart, u32 cycl)
 
 	assembler->FinalizeCode();
 	verify(assembler->GetBuffer()->GetCursorOffset() <= assembler->GetBuffer()->GetCapacity());
-	Arm64CacheFlush(codestart, assembler->GetBuffer()->GetEndAddress<void*>());
+	vmem_platform_flush_cache(
+		codestart, assembler->GetBuffer()->GetEndAddress<void*>(),
+		codestart, assembler->GetBuffer()->GetEndAddress<void*>());
 	icPtr += assembler->GetBuffer()->GetSizeInBytes();
 
 #if 0

--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -469,6 +469,7 @@ bool _vmem_reserve() {
 	}
 	else {
 		printf("Info: nvmem is enabled, with addr space of size %s\n", vmemstatus == MemType4GB ? "4GB" : "512MB");
+		printf("Info: p_sh4rcb: %p virt_ram_base: %p\n", p_sh4rcb, virt_ram_base);
 		// Map the different parts of the memory file into the new memory range we got.
 		#define MAP_RAM_START_OFFSET  0
 		#define MAP_VRAM_START_OFFSET (MAP_RAM_START_OFFSET+RAM_SIZE)

--- a/core/hw/mem/_vmem.h
+++ b/core/hw/mem/_vmem.h
@@ -24,6 +24,9 @@ void vmem_platform_ondemand_page(void *address, unsigned size_bytes);
 void vmem_platform_create_mappings(const vmem_mapping *vmem_maps, unsigned nummaps);
 // Just tries to wipe as much as possible in the relevant area.
 void vmem_platform_destroy();
+// Given a block of data in the .text section, prepares it for JIT action.
+// both code_area and size are page aligned.
+void vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code_area_rwx);
 
 // Note: if you want to disable vmem magic in any given platform, implement the
 // above functions as empty functions and make vmem_platform_init return MemTypeError.

--- a/core/hw/mem/_vmem.h
+++ b/core/hw/mem/_vmem.h
@@ -30,6 +30,8 @@ bool vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code
 // Same as above but uses two address spaces one with RX and RW protections.
 // Note: this function doesnt have to be implemented, it's a fallback for the above one.
 bool vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code_area_rw, uintptr_t *rx_offset);
+// This might not need an implementation (ie x86/64 cpus).
+void vmem_platform_flush_cache(void *icache_start, void *icache_end, void *dcache_start, void *dcache_end);
 
 // Note: if you want to disable vmem magic in any given platform, implement the
 // above functions as empty functions and make vmem_platform_init return MemTypeError.

--- a/core/hw/mem/_vmem.h
+++ b/core/hw/mem/_vmem.h
@@ -25,8 +25,11 @@ void vmem_platform_create_mappings(const vmem_mapping *vmem_maps, unsigned numma
 // Just tries to wipe as much as possible in the relevant area.
 void vmem_platform_destroy();
 // Given a block of data in the .text section, prepares it for JIT action.
-// both code_area and size are page aligned.
-void vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code_area_rwx);
+// both code_area and size are page aligned. Returns success.
+bool vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code_area_rwx);
+// Same as above but uses two address spaces one with RX and RW protections.
+// Note: this function doesnt have to be implemented, it's a fallback for the above one.
+bool vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code_area_rw, uintptr_t *rx_offset);
 
 // Note: if you want to disable vmem magic in any given platform, implement the
 // above functions as empty functions and make vmem_platform_init return MemTypeError.

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -1,18 +1,12 @@
 #include "types.h"
 
-#if HOST_OS==OS_WINDOWS
-#include <windows.h>
-#elif HOST_OS==OS_LINUX
-#include <unistd.h>
-#include <sys/mman.h>
-#endif
-
 #include "../sh4_interpreter.h"
 #include "../sh4_opcode_list.h"
 #include "../sh4_core.h"
 #include "../sh4_if.h"
 #include "hw/sh4/sh4_interrupts.h"
 
+#include "hw/mem/_vmem.h"
 #include "hw/sh4/sh4_mem.h"
 #include "hw/pvr/pvr_mem.h"
 #include "hw/aica/aica_if.h"
@@ -26,9 +20,7 @@
 #include "decoder.h"
 
 #if FEAT_SHREC != DYNAREC_NONE
-//uh uh
 
-#if !defined(_WIN64)
 u8 SH4_TCB[CODE_SIZE+4096]
 #if HOST_OS == OS_WINDOWS || FEAT_SHREC != DYNAREC_JIT
 	;
@@ -38,7 +30,6 @@ u8 SH4_TCB[CODE_SIZE+4096]
 	__attribute__((section("__TEXT,.text")));
 #else
 	#error SH4_TCB ALLOC
-#endif
 #endif
 
 u8* CodeCache;
@@ -455,55 +446,17 @@ void recSh4_Init()
 	if (_nvmem_enabled()) {
 		verify(mem_b.data==((u8*)p_sh4rcb->sq_buffer+512+0x0C000000));
 	}
-	
-#if defined(_WIN64)
-#ifdef _MSC_VER
-	for (int i = 10; i < 1300; i++) {
 
+	// Prepare some pointer to the pre-allocated code cache:
+	void *candidate_ptr = (void*)(((unat)SH4_TCB + 4095) & ~4095);
 
-		//align to next page ..
-		u8* ptr = (u8*)recSh4_Init - i * 1024 * 1024;
-
-		CodeCache = (u8*)VirtualAlloc(ptr, CODE_SIZE, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);//; (u8*)(((unat)SH4_TCB+4095)& ~4095);
-
-		if (CodeCache)
-			break;
-	}
-#else
-	CodeCache = (u8*)VirtualAlloc(NULL, CODE_SIZE, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-#endif
+	// Call the platform-specific magic to make the pages RWX
+	CodeCache = NULL;
+	vmem_platform_prepare_jit_block(candidate_ptr, CODE_SIZE, (void**)&CodeCache);
+	// Ensure the pointer returned is non-null
 	verify(CodeCache != NULL);
-#else
-	CodeCache = (u8*)(((unat)SH4_TCB+4095)& ~4095);
-#endif
 
-#if HOST_OS == OS_DARWIN
-    munmap(CodeCache, CODE_SIZE);
-    CodeCache = (u8*)mmap(CodeCache, CODE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_PRIVATE | MAP_ANON, 0, 0);
-#endif
-
-#if HOST_OS == OS_WINDOWS
-	DWORD old;
-	VirtualProtect(CodeCache,CODE_SIZE,PAGE_EXECUTE_READWRITE,&old);
-#elif HOST_OS == OS_LINUX || HOST_OS == OS_DARWIN
-	
-	printf("\n\t CodeCache addr: %p | from: %p | addr here: %p\n", CodeCache, CodeCache, recSh4_Init);
-
-	#if FEAT_SHREC == DYNAREC_JIT
-		if (mprotect(CodeCache, CODE_SIZE, PROT_READ|PROT_WRITE|PROT_EXEC))
-		{
-			perror("\n\tError,Couldn’t mprotect CodeCache!");
-			die("Couldn’t mprotect CodeCache");
-		}
-	#endif
-
-#if TARGET_IPHONE
-	memset((u8*)mmap(CodeCache, CODE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_FIXED | MAP_PRIVATE | MAP_ANON, 0, 0),0xFF,CODE_SIZE);
-#else
-	memset(CodeCache,0xFF,CODE_SIZE);
-#endif
-
-#endif
+	memset(CodeCache, 0xFF, CODE_SIZE);
 	ngen_init();
 }
 
@@ -532,4 +485,5 @@ void Get_Sh4Recompiler(sh4_if* rv)
 	rv->IsCpuRunning = recSh4_IsCpuRunning;
 	rv->ResetCache = recSh4_ClearCache;
 }
-#endif
+
+#endif  // FEAT_SHREC != DYNAREC_NONE

--- a/core/hw/sh4/dyna/ngen.h
+++ b/core/hw/sh4/dyna/ngen.h
@@ -55,8 +55,8 @@
 // sub/add the pointer offset. CodeCache will point to the RW pointer for simplicity.
 #ifdef FEAT_NO_RWX_PAGES
 	extern uintptr_t cc_rx_offset;
-	#define CC_RW2RX(ptr) (void*)(((uintptr_t)ptr) + cc_rx_offset)
-	#define CC_RX2RW(ptr) (void*)(((uintptr_t)ptr) - cc_rx_offset)
+	#define CC_RW2RX(ptr) (void*)(((uintptr_t)(ptr)) + cc_rx_offset)
+	#define CC_RX2RW(ptr) (void*)(((uintptr_t)(ptr)) - cc_rx_offset)
 #else
 	#define CC_RW2RX(ptr) (ptr)
 	#define CC_RX2RW(ptr) (ptr)

--- a/core/hw/sh4/dyna/ngen.h
+++ b/core/hw/sh4/dyna/ngen.h
@@ -48,6 +48,19 @@
 
 #define CODE_SIZE   (10*1024*1024)
 
+// When NO_RWX is enabled there's two address-spaces, one executable and
+// one writtable. The emitter and most of the code in rec-* will work with
+// the RW pointer. However the fpcb table and other pointers during execution
+// (ie. exceptions) are RX pointers. These two macros convert between them by
+// sub/add the pointer offset. CodeCache will point to the RW pointer for simplicity.
+#ifdef FEAT_NO_RWX_PAGES
+	extern uintptr_t cc_rx_offset;
+	#define CC_RW2RX(ptr) (void*)(((uintptr_t)ptr) + cc_rx_offset)
+	#define CC_RX2RW(ptr) (void*)(((uintptr_t)ptr) - cc_rx_offset)
+#else
+	#define CC_RW2RX(ptr) (ptr)
+	#define CC_RX2RW(ptr) (ptr)
+#endif
 
 //alternative emit ptr, set to 0 to use the main buffer
 extern u32* emit_ptr;

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -59,12 +59,8 @@ void fault_handler (int sn, siginfo_t * si, void *segfault_ctx)
 
 	context_from_segfault(&ctx, segfault_ctx);
 
-	bool dyna_cde = ((unat)ctx.pc>(unat)CodeCache) && ((unat)ctx.pc<(unat)(CodeCache + CODE_SIZE));
+	bool dyna_cde = ((unat)CC_RX2RW(ctx.pc) > (unat)CodeCache) && ((unat)CC_RX2RW(ctx.pc) < (unat)(CodeCache + CODE_SIZE));
 
-	//ucontext_t* ctx=(ucontext_t*)ctxr;
-	//printf("mprot hit @ ptr 0x%08X @@ code: %08X, %d\n",si->si_addr,ctx->uc_mcontext.arm_pc,dyna_cde);
-
-	
 	if (VramLockedWrite((u8*)si->si_addr) || BM_LockedWrite((u8*)si->si_addr))
 		return;
 	#if FEAT_SHREC == DYNAREC_JIT

--- a/core/rec-ARM64/rec_arm64.cpp
+++ b/core/rec-ARM64/rec_arm64.cpp
@@ -1442,13 +1442,14 @@ void ngen_CC_Finish(shil_opcode* op)
 bool ngen_Rewrite(unat& host_pc, unat, unat)
 {
 	//printf("ngen_Rewrite pc %p\n", host_pc);
-	RuntimeBlockInfo *block = bm_GetBlock((void *)host_pc);
+	void *host_pc_rw = CC_RX2RW(host_pc);
+	RuntimeBlockInfo *block = bm_GetBlock((void*)host_pc);
 	if (block == NULL)
 	{
 		printf("ngen_Rewrite: Block at %p not found\n", (void *)host_pc);
 		return false;
 	}
-	u32 *code_ptr = (u32*)host_pc;
+	u32 *code_ptr = (u32*)host_pc_rw;
 	auto it = block->memory_accesses.find(code_ptr);
 	if (it == block->memory_accesses.end())
 	{
@@ -1466,7 +1467,7 @@ bool ngen_Rewrite(unat& host_pc, unat, unat)
 		assembler->GenWriteMemorySlow(op);
 	assembler->Finalize(true);
 	delete assembler;
-	host_pc = (unat)(code_ptr - 2);
+	host_pc = (unat)CC_RW2RX(code_ptr - 2);
 
 	return true;
 }

--- a/core/rec-ARM64/rec_arm64.cpp
+++ b/core/rec-ARM64/rec_arm64.cpp
@@ -1442,7 +1442,7 @@ void ngen_CC_Finish(shil_opcode* op)
 bool ngen_Rewrite(unat& host_pc, unat, unat)
 {
 	//printf("ngen_Rewrite pc %p\n", host_pc);
-	void *host_pc_rw = CC_RX2RW(host_pc);
+	void *host_pc_rw = (void*)CC_RX2RW(host_pc);
 	RuntimeBlockInfo *block = bm_GetBlock((void*)host_pc);
 	if (block == NULL)
 	{

--- a/core/windows/win_vmem.cpp
+++ b/core/windows/win_vmem.cpp
@@ -183,7 +183,7 @@ bool vmem_platform_prepare_jit_block(void *code_area, unsigned size, void **code
 
 	*code_area_rw = ptr_rw;
 	*rx_offset = (char*)ptr_rx - (char*)ptr_rw;
-	printf("Info: Using NO_RWX mode, rx ptr: %p, rw ptr: %p, offset: %p\n", ptr_rx, ptr_rw, *rx_offset);
+	printf("Info: Using NO_RWX mode, rx ptr: %p, rw ptr: %p, offset: %lu\n", ptr_rx, ptr_rw, (unsigned long)*rx_offset);
 
 	return (ptr_rw != NULL);
 }


### PR DESCRIPTION
There's still stuff related to mprotect/mmap in places like Naomi and ARM-AREC, but I will ignore them for now.
Implemented the NO_RWX in the vmem and added support in the driver. Also added support for x64 and ARM64 recs. This is not meant to be used by general builds/releases but only for platforms which require it (Switch and perhaps UWP).
