### PR TITLE
Add per-strip translucent polygons sort option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ endif()
 
 add_definitions(/DFEAT_HAS_SOFTREND=0)
 
+if(${BUILD_COMPILER} EQUAL ${COMPILER_VC})
+	# appveyor heap size issue
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} "/Zm200")
+endif()
+
 
 ### deps.cmake #################################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ add_definitions(/DFEAT_HAS_SOFTREND=0)
 
 if(${BUILD_COMPILER} EQUAL ${COMPILER_VC})
 	# appveyor heap size issue
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} "/Zm200")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zm200")
 endif()
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ before_build:
   - cmd: >-
       if "%CONFIGURATION%"=="RelWithDebInfo" (set BUILD_PATH=build)
       
+      if "%CONFIGURATION%"=="RelWithDebInfo" (vcvars64.bat)
+
       if "%CONFIGURATION%"=="fast" (set BUILD_PATH=shell\linux)
       
       set EXTRA_PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ before_build:
   - cmd: >-
       if "%CONFIGURATION%"=="RelWithDebInfo" (set BUILD_PATH=build)
       
-      if "%CONFIGURATION%"=="RelWithDebInfo" (vcvars64.bat)
+      if "%CONFIGURATION%"=="RelWithDebInfo" ("C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64)
 
       if "%CONFIGURATION%"=="fast" (set BUILD_PATH=shell\linux)
       

--- a/core/hw/aica/aica_if.cpp
+++ b/core/hw/aica/aica_if.cpp
@@ -160,6 +160,8 @@ void aica_Init()
 void aica_Reset(bool Manual)
 {
 	aica_Init();
+	VREG = 0;
+	ARMRST = 0;
 }
 
 void aica_Term()

--- a/core/hw/arm7/arm7.cpp
+++ b/core/hw/arm7/arm7.cpp
@@ -69,12 +69,6 @@ bool Arm7Enabled=false;
 
 u8 cpuBitsSet[256];
 
-bool intState = false;
-bool stopState = false;
-bool holdState = false;
-
-
-
 void CPUSwitchMode(int mode, bool saveState, bool breakLoop=true);
 extern "C" void CPUFiq();
 void CPUUpdateCPSR();

--- a/core/hw/flashrom/flashrom.h
+++ b/core/hw/flashrom/flashrom.h
@@ -21,7 +21,7 @@ struct MemChip
 		this->mask=size-1;//must be power of 2
 		this->write_protect_size = write_protect_size;
 	}
-	~MemChip() { delete[] data; }
+	virtual ~MemChip() { delete[] data; }
 
 	virtual u8 Read8(u32 addr)
 	{
@@ -118,14 +118,11 @@ struct MemChip
 
 		printf("Saved %s as %s\n\n",path,title.c_str());
 	}
+	virtual void Reset() {}
 };
 struct RomChip : MemChip
 {
 	RomChip(u32 sz, u32 write_protect_size = 0) : MemChip(sz, write_protect_size) {}
-	void Reset()
-	{
-		//nothing, its permanent read only ;p
-	}
 	void Write(u32 addr,u32 data,u32 sz)
 	{
 		die("Write to RomChip is not possible, address=%x, data=%x, size=%d");
@@ -135,10 +132,6 @@ struct SRamChip : MemChip
 {
 	SRamChip(u32 sz, u32 write_protect_size = 0) : MemChip(sz, write_protect_size) {}
 
-	void Reset()
-	{
-		//nothing, its battery backed up storage
-	}
 	void Write(u32 addr,u32 val,u32 sz)
 	{
 		addr&=mask;
@@ -234,7 +227,7 @@ struct DCFlashChip : MemChip
 	};
 
 	FlashState state;
-	void Reset()
+	virtual void Reset() override
 	{
 		//reset the flash chip state
 		state = FS_Normal;

--- a/core/hw/gdrom/gdromv3.cpp
+++ b/core/hw/gdrom/gdromv3.cpp
@@ -322,6 +322,13 @@ u32 GetFAD(u8* data, bool msf)
 void libCore_gdrom_disc_change()
 {
 	gd_setdisc();
+	read_params = { 0 };
+	set_mode_offset = 0;
+	packet_cmd = { 0 };
+	read_buff = { 0 };
+	pio_buff = { gds_waitcmd, 0 };
+	ata_cmd = { 0 };
+	cdda = { 0 };
 }
 
 //This handles the work of setting up the pio regs/state :)

--- a/core/hw/gdrom/gdromv3.cpp
+++ b/core/hw/gdrom/gdromv3.cpp
@@ -5,16 +5,10 @@
 
 #include "gdromv3.h"
 
-#include "types.h"
 #include "hw/sh4/sh4_mem.h"
 #include "hw/holly/sb.h"
 #include "hw/sh4/modules/dmac.h"
-#include "hw/sh4/sh4_core.h"
 #include "hw/holly/holly_intc.h"
-
-#include "hw/sh4/sh4_mmr.h"
-#include "hw/sh4/sh4_sched.h"
-
 #include "hw/sh4/sh4_sched.h"
 
 int gdrom_schid;

--- a/core/hw/holly/sb_mem.cpp
+++ b/core/hw/holly/sb_mem.cpp
@@ -41,7 +41,7 @@ bool LoadRomFiles(const string& root)
 	{
 #if DC_PLATFORM == DC_PLATFORM_DREAMCAST
 		// Dreamcast absolutely needs a BIOS
-		msgboxf("Unable to find bios in \n%s\nExiting...", MBX_ICONERROR, root.c_str());
+		msgboxf("Unable to find bios in %s. Exiting...", MBX_ICONERROR, root.c_str());
 		return false;
 #endif
 	}
@@ -348,6 +348,10 @@ void sh4_area0_Init()
 void sh4_area0_Reset(bool Manual)
 {
 	sb_Reset(Manual);
+	sys_rom.Reset();
+#if defined(FLASH_SIZE) || defined(BBSRAM_SIZE)
+	sys_nvmem.Reset();
+#endif
 }
 
 void sh4_area0_Term()

--- a/core/hw/pvr/Renderer_if.cpp
+++ b/core/hw/pvr/Renderer_if.cpp
@@ -88,10 +88,8 @@ cResetEvent rs, re;
 int max_idx,max_mvo,max_op,max_pt,max_tr,max_vtx,max_modt, ovrn;
 
 static bool render_called = false;
-u32 fb1_watch_addr_start;
-u32 fb1_watch_addr_end;
-u32 fb2_watch_addr_start;
-u32 fb2_watch_addr_end;
+u32 fb_watch_addr_start;
+u32 fb_watch_addr_end;
 bool fb_dirty;
 
 TA_context* _pvrrc;
@@ -558,10 +556,8 @@ void rend_vblank()
 void check_framebuffer_write()
 {
 	u32 fb_size = (FB_R_SIZE.fb_y_size + 1) * (FB_R_SIZE.fb_x_size + FB_R_SIZE.fb_modulus) * 4;
-	fb1_watch_addr_start = FB_R_SOF1 & VRAM_MASK;
-	fb1_watch_addr_end = fb1_watch_addr_start + fb_size;
-	fb2_watch_addr_start = FB_R_SOF2 & VRAM_MASK;
-	fb2_watch_addr_end = fb2_watch_addr_start + fb_size;
+	fb_watch_addr_start = FB_R_SOF2 & VRAM_MASK;
+	fb_watch_addr_end = fb_watch_addr_start + fb_size;
 }
 
 void rend_cancel_emu_wait()

--- a/core/hw/pvr/Renderer_if.h
+++ b/core/hw/pvr/Renderer_if.h
@@ -61,10 +61,8 @@ Renderer* rend_GL4();
 Renderer* rend_norend();
 Renderer* rend_softrend();
 
-extern u32 fb1_watch_addr_start;
-extern u32 fb1_watch_addr_end;
-extern u32 fb2_watch_addr_start;
-extern u32 fb2_watch_addr_end;
+extern u32 fb_watch_addr_start;
+extern u32 fb_watch_addr_end;
 extern bool fb_dirty;
 
 void check_framebuffer_write();

--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -233,9 +233,7 @@ void DYNACALL pvr_write_area1_8(u32 addr,u8 data)
 void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 {
     u32 vaddr = addr & VRAM_MASK;
-    if (!fb_dirty
-        && ((vaddr >= fb1_watch_addr_start && vaddr < fb1_watch_addr_end)
-            || (vaddr >= fb2_watch_addr_start && vaddr < fb2_watch_addr_end)))
+    if (!fb_dirty && vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
     {
         fb_dirty = true;
     }
@@ -244,9 +242,7 @@ void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 void DYNACALL pvr_write_area1_32(u32 addr,u32 data)
 {
     u32 vaddr = addr & VRAM_MASK;
-    if (!fb_dirty
-        && ((vaddr >= fb1_watch_addr_start && vaddr < fb1_watch_addr_end)
-            || (vaddr >= fb2_watch_addr_start && vaddr < fb2_watch_addr_end)))
+    if (!fb_dirty && vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
     {
         fb_dirty = true;
     }

--- a/core/hw/pvr/pvr_mem.cpp
+++ b/core/hw/pvr/pvr_mem.cpp
@@ -233,7 +233,7 @@ void DYNACALL pvr_write_area1_8(u32 addr,u8 data)
 void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 {
     u32 vaddr = addr & VRAM_MASK;
-    if (!fb_dirty && vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
+    if (vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
     {
         fb_dirty = true;
     }
@@ -242,7 +242,7 @@ void DYNACALL pvr_write_area1_16(u32 addr,u16 data)
 void DYNACALL pvr_write_area1_32(u32 addr,u32 data)
 {
     u32 vaddr = addr & VRAM_MASK;
-    if (!fb_dirty && vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
+    if (vaddr >= fb_watch_addr_start && vaddr < fb_watch_addr_end)
     {
         fb_dirty = true;
     }

--- a/core/hw/pvr/ta.h
+++ b/core/hw/pvr/ta.h
@@ -20,5 +20,3 @@ void DYNACALL ta_vtx_data32(void* data);
 void ta_vtx_data(u32* data, u32 size);
 
 bool ta_parse_vdrc(TA_context* ctx);
-
-#define TRIG_SORT 1

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -521,6 +521,7 @@ void InitSettings()
 	settings.rend.Fog				= true;
 	settings.rend.FloatVMUs			= false;
 	settings.rend.Rotate90			= false;
+	settings.rend.PerStripSorting	= false;
 
 	settings.pvr.ta_skip			= 0;
 	settings.pvr.rend				= 0;
@@ -609,6 +610,7 @@ void LoadSettings(bool game_specific)
 	settings.rend.Fog				= cfgLoadBool(config_section, "rend.Fog", settings.rend.Fog);
 	settings.rend.FloatVMUs			= cfgLoadBool(config_section, "rend.FloatVMUs", settings.rend.FloatVMUs);
 	settings.rend.Rotate90			= cfgLoadBool(config_section, "rend.Rotate90", settings.rend.Rotate90);
+	settings.rend.PerStripSorting	= cfgLoadBool(config_section, "rend.PerStripSorting", settings.rend.PerStripSorting);
 
 	settings.pvr.ta_skip			= cfgLoadInt(config_section, "ta.skip", settings.pvr.ta_skip);
 	settings.pvr.rend				= cfgLoadInt(config_section, "pvr.rend", settings.pvr.rend);
@@ -759,6 +761,7 @@ void SaveSettings()
 	cfgSaveBool("config", "rend.Rotate90", settings.rend.Rotate90);
 	cfgSaveInt("config", "ta.skip", settings.pvr.ta_skip);
 	cfgSaveInt("config", "pvr.rend", settings.pvr.rend);
+	cfgSaveBool("config", "rend.PerStripSorting", settings.rend.PerStripSorting);
 
 	cfgSaveInt("config", "pvr.MaxThreads", settings.pvr.MaxThreads);
 	cfgSaveBool("config", "pvr.SynchronousRendering", settings.pvr.SynchronousRender);

--- a/core/rend/gles/gldraw.cpp
+++ b/core/rend/gles/gldraw.cpp
@@ -260,11 +260,9 @@ __forceinline
 		glcache.DepthFunc(Zfunction[gp->isp.DepthMode]);
 	}
 
-#if TRIG_SORT
-	if (SortingEnabled)
+	if (SortingEnabled && !settings.rend.PerStripSorting)
 		glcache.DepthMask(GL_FALSE);
 	else
-#endif
 		glcache.DepthMask(!gp->isp.ZWriteDis);
 }
 
@@ -1105,13 +1103,16 @@ void DrawStrips()
 		{
 			if (current_pass.autosort)
             {
-#if TRIG_SORT
-				GenSorted(previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
-				DrawSorted(render_pass < pvrrc.render_passes.used() - 1);
-#else
-                SortPParams(previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
-                DrawList<ListType_Translucent,true>(pvrrc.global_param_tr, previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
-#endif
+				if (!settings.rend.PerStripSorting)
+				{
+					GenSorted(previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
+					DrawSorted(render_pass < pvrrc.render_passes.used() - 1);
+				}
+				else
+				{
+					SortPParams(previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
+					DrawList<ListType_Translucent,true>(pvrrc.global_param_tr, previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);
+				}
             }
 			else
 				DrawList<ListType_Translucent,false>(pvrrc.global_param_tr, previous_pass.tr_count, current_pass.tr_count - previous_pass.tr_count);

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -943,7 +943,11 @@ static void gui_display_settings()
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, normal_padding);
 			int renderer = settings.pvr.rend == 3 ? 2 : settings.rend.PerStripSorting ? 1 : 0;
+#if HOST_OS != OS_DARWIN
 			bool has_per_pixel = !gl.is_gles && gl.gl_major >= 4;
+#else
+			bool has_per_pixel = false;
+#endif
 		    if (ImGui::CollapsingHeader("Transparent Sorting", ImGuiTreeNodeFlags_DefaultOpen))
 		    {
 		    	ImGui::Columns(has_per_pixel ? 3 : 2, "renderers", false);

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -942,20 +942,41 @@ static void gui_display_settings()
 		if (ImGui::BeginTabItem("Video"))
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, normal_padding);
-#if !defined(GLES) && HOST_OS != OS_DARWIN
-		    if (!gl.is_gles && gl.gl_major >= 4 && ImGui::CollapsingHeader("Transparent Sorting", ImGuiTreeNodeFlags_DefaultOpen))
+			int renderer = settings.pvr.rend == 3 ? 2 : settings.rend.PerStripSorting ? 1 : 0;
+			bool has_per_pixel = !gl.is_gles && gl.gl_major >= 4;
+		    if (ImGui::CollapsingHeader("Transparent Sorting", ImGuiTreeNodeFlags_DefaultOpen))
 		    {
-		    	ImGui::Columns(2, "renderers", false);
-		    	ImGui::RadioButton("Per Triangle", (int *)&settings.pvr.rend, 0);
+		    	ImGui::Columns(has_per_pixel ? 3 : 2, "renderers", false);
+		    	ImGui::RadioButton("Per Triangle", &renderer, 0);
 	            ImGui::SameLine();
 	            ShowHelpMarker("Sort transparent polygons per triangle. Fast but may produce graphical glitches");
-		    	ImGui::NextColumn();
-		    	ImGui::RadioButton("Per Pixel", (int *)&settings.pvr.rend, 3);
+            	ImGui::NextColumn();
+		    	ImGui::RadioButton("Per Strip", &renderer, 1);
 	            ImGui::SameLine();
-	            ShowHelpMarker("Sort transparent polygons per pixel. Slower but accurate");
+	            ShowHelpMarker("Sort transparent polygons per strip. Faster but may produce graphical glitches");
+	            if (has_per_pixel)
+	            {
+	            	ImGui::NextColumn();
+	            	ImGui::RadioButton("Per Pixel", &renderer, 2);
+	            	ImGui::SameLine();
+	            	ShowHelpMarker("Sort transparent polygons per pixel. Slower but accurate");
+	            }
 		    	ImGui::Columns(1, NULL, false);
+		    	switch (renderer)
+		    	{
+		    	case 0:
+		    		settings.pvr.rend = 0;
+		    		settings.rend.PerStripSorting = false;
+		    		break;
+		    	case 1:
+		    		settings.pvr.rend = 0;
+		    		settings.rend.PerStripSorting = true;
+		    		break;
+		    	case 2:
+		    		settings.pvr.rend = 3;
+		    		break;
+		    	}
 		    }
-#endif
 		    if (ImGui::CollapsingHeader("Rendering Options", ImGuiTreeNodeFlags_DefaultOpen))
 		    {
 		    	ImGui::Checkbox("Synchronous Rendering", &settings.pvr.SynchronousRender);

--- a/core/serialize.cpp
+++ b/core/serialize.cpp
@@ -54,9 +54,6 @@ extern bool armFiqEnable;
 extern int armMode;
 extern bool Arm7Enabled;
 extern u8 cpuBitsSet[256];
-extern bool intState ;
-extern bool stopState ;
-extern bool holdState ;
 /*
 	if AREC dynarec enabled:
 	vector<ArmDPOP> ops;
@@ -256,15 +253,6 @@ extern u32 FrameCount;
 //the renderer thread - one time set
 //extern cThread rthd;
 extern bool pend_rend;
-
-//these will all get cleared out after a few frames - no need to serialize
-//static bool render_called = false;
-//u32 fb1_watch_addr_start;
-//u32 fb1_watch_addr_end;
-//u32 fb2_watch_addr_start;
-//u32 fb2_watch_addr_end;
-//bool fb_dirty;
-
 
 //maybe
 //extern u32 memops_t,memops_l;
@@ -722,18 +710,6 @@ extern u32 fallback_blocks;
 extern u32 total_blocks;
 extern u32 REMOVED_OPS;
 
-
-
-
-//./core/linux-dist/main.cpp, ./core/windows/winmain.cpp , ...
-extern u16 kcode[4];
-extern u8 rt[4];
-extern u8 lt[4];
-extern u32 vks[4];
-extern s8 joyx[4];
-extern s8 joyy[4];
-
-
 bool rc_serialize(void *src, unsigned int src_size, void **dest, unsigned int *total_size)
 {
 	if ( *dest != NULL )
@@ -812,9 +788,10 @@ bool dc_serialize(void **data, unsigned int *total_size)
 	REICAST_S(armMode);
 	REICAST_S(Arm7Enabled);
 	REICAST_SA(cpuBitsSet,256);
-	REICAST_S(intState);
-	REICAST_S(stopState);
-	REICAST_S(holdState);
+	bool dummy;
+	REICAST_S(dummy);
+	REICAST_S(dummy);
+	REICAST_S(dummy);
 
 	REICAST_S(dsp);
 
@@ -1132,12 +1109,16 @@ bool dc_serialize(void **data, unsigned int *total_size)
 	REICAST_S(total_blocks);
 	REICAST_S(REMOVED_OPS);
 
-	REICAST_SA(kcode,4);
-	REICAST_SA(rt,4);
-	REICAST_SA(lt,4);
-	REICAST_SA(vks,4);
-	REICAST_SA(joyx,4);
-	REICAST_SA(joyy,4);
+	REICAST_S(i); //REICAST_SA(kcode,4);
+	REICAST_S(i);
+	REICAST_S(i); //REICAST_SA(rt,4);
+	REICAST_S(i); //REICAST_SA(lt,4);
+	REICAST_S(i); //REICAST_SA(vks,4);
+	REICAST_S(i);
+	REICAST_S(i);
+	REICAST_S(i);
+	REICAST_S(i); //REICAST_SA(joyx,4);
+	REICAST_S(i); //REICAST_SA(joyy,4);
 
 	REICAST_S(settings.dreamcast.broadcast);
 	REICAST_S(settings.dreamcast.cable);
@@ -1166,9 +1147,10 @@ static bool dc_unserialize_libretro(void **data, unsigned int *total_size)
 	REICAST_US(armMode);
 	REICAST_US(Arm7Enabled);
 	REICAST_USA(cpuBitsSet,256);
-	REICAST_US(intState);
-	REICAST_US(stopState);
-	REICAST_US(holdState);
+	bool dummy;
+	REICAST_US(dummy);
+	REICAST_US(dummy);
+	REICAST_US(dummy);
 
 	REICAST_US(dsp);
 
@@ -1562,9 +1544,10 @@ bool dc_unserialize(void **data, unsigned int *total_size)
 	REICAST_US(armMode);
 	REICAST_US(Arm7Enabled);
 	REICAST_USA(cpuBitsSet,256);
-	REICAST_US(intState);
-	REICAST_US(stopState);
-	REICAST_US(holdState);
+	bool dummy;
+	REICAST_US(dummy);
+	REICAST_US(dummy);
+	REICAST_US(dummy);
 
 	REICAST_US(dsp);
 
@@ -1901,12 +1884,16 @@ bool dc_unserialize(void **data, unsigned int *total_size)
 	REICAST_US(total_blocks);
 	REICAST_US(REMOVED_OPS);
 
-	REICAST_USA(kcode,4);
-	REICAST_USA(rt,4);
-	REICAST_USA(lt,4);
-	REICAST_USA(vks,4);
-	REICAST_USA(joyx,4);
-	REICAST_USA(joyy,4);
+	REICAST_US(i); //REICAST_USA(kcode,4);
+	REICAST_US(i);
+	REICAST_US(i); //REICAST_USA(rt,4);
+	REICAST_US(i); //REICAST_USA(lt,4);
+	REICAST_US(i); //REICAST_USA(vks,4);
+	REICAST_US(i);
+	REICAST_US(i);
+	REICAST_US(i);
+	REICAST_US(i); //REICAST_USA(joyx,4);
+	REICAST_US(i); //REICAST_USA(joyy,4);
 
 
 	REICAST_US(settings.dreamcast.broadcast);

--- a/core/types.h
+++ b/core/types.h
@@ -638,6 +638,7 @@ struct settings_t
 		bool Fog;
 		bool FloatVMUs;
 		bool Rotate90;			// Rotate the screen 90 deg CC
+		bool PerStripSorting;
 	} rend;
 
 	struct

--- a/shell/reicast.vcxproj
+++ b/shell/reicast.vcxproj
@@ -715,7 +715,7 @@
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -754,7 +754,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;TARGET_NAOMI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -793,7 +793,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -834,7 +834,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;TARGET_NAOMI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/shell/reicast.vcxproj
+++ b/shell/reicast.vcxproj
@@ -715,7 +715,7 @@
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -754,7 +754,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;TARGET_NAOMI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -793,7 +793,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -834,7 +834,7 @@ for /f "delims=" %%i in ('date /T') do echo #define BUILD_DATE "%%i" &gt;&gt;$(P
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>WIN32;CHD5_FLAC;PACKAGE_VERSION="1.3.2";FLAC__HAS_OGG=0;FLAC__NO_DLL;HAVE_LROUND;HAVE_STDINT_H;HAVE_STDLIB_H;CHD5_LZMA;_7ZIP_ST;NDEBUG;_CONSOLE;X86;RELEASE;TARGET_NAOMI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)..\core\;$(ProjectDir)..\core\khronos;$(ProjectDir)..\core\rend\gles;$(ProjectDir)..\core\deps;$(ProjectDir)..\core\deps\flac\src\libflac\include;$(ProjectDir)..\core\deps\flac\include</AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/MP %(AdditionalOptions)</AdditionalOptions>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>


### PR DESCRIPTION
User can now select per-triangle (default), per-strip and per-pixel (GL 4.3 only)
The per-strip mode should help Shenmue users who can't use GL 4.3

 Use FB_R_SOF2 only to detect direct FB writes (Virtua Fighter 3tb flashing FMV)

Other reset-related fixes
