### PR TITLE
Build fails on GLES2 platform after commit a6b773a "Merge pull request #1603"

### DIFF
--- a/core/build.h
+++ b/core/build.h
@@ -441,4 +441,6 @@
 #if defined(GLES) && !defined(GLES3)
 // Only use GL ES 2.0 API functions
 #define GLES2
+// but define this unneeded function, called from the same compilation unit as some GLES2 functions
+#define glBlitFramebuffer __rglgen_glBlitFramebuffer
 #endif


### PR DESCRIPTION
| Platform | Branch | Hash | CIDL |
|---|---|---|---|
| S905x Mali 450 | Master | a6b773a | self build |

**_Description of the Issue_**
Previously successful builds.  Now fails with this commit.

**_Build output_**
```
obj-dreamcast-vero4k-neon/rend/gles/gldraw.build_obj: In function `render_output_framebuffer()':
/home/osmc/reicast-emulator/shell/linux/../../core/rend/gles/gldraw.cpp:1182: undefined reference to `glBlitFramebuffer'
collect2: error: ld returned 1 exit status
```

**_Debugging Steps Tested_**
* Bisected to commit `a6b773a`
* glBlitFramebuffer (see logs) not referenced in any of my GLES headers, but in gl32funcs.h
* From this commit gl32funcs.h is no longer included for GLES2:
https://github.com/reicast/reicast-emulator/blob/a6b773a23e4167f953108e90711d5eeceed37f11/core/rend/gles/gles.h#L20-L22
* But still referenced by code that for GLES2 should never be called:
https://github.com/reicast/reicast-emulator/blob/a6b773a23e4167f953108e90711d5eeceed37f11/core/rend/gles/gldraw.cpp#L1164-L1184

