### PR TITLE
Implement fast memory ops on x64

### DIFF
--- a/core/hw/sh4/dyna/blockmanager.h
+++ b/core/hw/sh4/dyna/blockmanager.h
@@ -72,7 +72,14 @@ struct RuntimeBlockInfo: RuntimeBlockInfo_Core
 
 	u32 memops;
 	u32 linkedmemops;
-	std::map<void*, u32> memory_accesses;	// key is host pc when access is made, value is opcode id
+	// key is a host pc for a load/store in a jit block
+	// value contains information for mem-op rewriting purposes.
+	struct memop_info {
+		uint16_t opid;
+		uint8_t  rewrite_offset;
+		uint8_t  emitted_bytes;
+	};		
+	std::map<void*, memop_info> memory_accesses;
 };
 
 struct CachedBlockInfo: RuntimeBlockInfo_Core

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -82,7 +82,10 @@ void fault_handler (int sn, siginfo_t * si, void *segfault_ctx)
 				context_to_segfault(&ctx, segfault_ctx);
 			}
 		#elif HOST_CPU == CPU_X64
-			//x64 has no rewrite support
+			else if (dyna_cde && ngen_Rewrite((unat&)ctx.pc, 0, 0))
+			{
+				context_to_segfault(&ctx, segfault_ctx);
+			}
 		#elif HOST_CPU == CPU_ARM64
 			else if (dyna_cde && ngen_Rewrite(ctx.pc, 0, 0))
 			{

--- a/core/windows/win_vmem.cpp
+++ b/core/windows/win_vmem.cpp
@@ -34,10 +34,12 @@ static char * base_alloc = NULL;
 VMemType vmem_platform_init(void **vmem_base_addr, void **sh4rcb_addr) {
 	// Firt let's try to allocate the in-memory file
 	mem_handle = CreateFileMapping(INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, 0, RAM_SIZE_MAX + VRAM_SIZE_MAX + ARAM_SIZE_MAX, 0);
+	verify(mem_handle != INVALID_HANDLE_VALUE);
 
 	// Now allocate the actual address space (it will be 64KB aligned on windows).
 	unsigned memsize = 512*1024*1024 + sizeof(Sh4RCB) + ARAM_SIZE_MAX;
 	base_alloc = (char*)VirtualAlloc(0, memsize, MEM_RESERVE, PAGE_NOACCESS);
+	verify(base_alloc != NULL);
 
 	// Calculate pointers now
 	*sh4rcb_addr = &base_alloc[0];

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -152,7 +152,8 @@ LONG ExeptionHandler(EXCEPTION_POINTERS *ExceptionInfo)
 	{
 		return EXCEPTION_CONTINUE_EXECUTION;
 	}
-#if FEAT_SHREC == DYNAREC_JIT && HOST_CPU == CPU_X86
+#if FEAT_SHREC == DYNAREC_JIT
+	#if HOST_CPU == CPU_X86
 		else if ( ngen_Rewrite((unat&)ep->ContextRecord->Eip,*(unat*)ep->ContextRecord->Esp,ep->ContextRecord->Eax) )
 		{
 			//remove the call from call stack
@@ -161,6 +162,12 @@ LONG ExeptionHandler(EXCEPTION_POINTERS *ExceptionInfo)
 			ep->ContextRecord->Ecx=ep->ContextRecord->Eax;
 			return EXCEPTION_CONTINUE_EXECUTION;
 		}
+	#elif HOST_CPU == CPU_X64
+		else if (ngen_Rewrite((unat&)ep->ContextRecord->Rip, 0, 0))
+		{
+			return EXCEPTION_CONTINUE_EXECUTION;
+		}
+	#endif
 #endif
 	else
 	{


### PR DESCRIPTION
These includes a small rewrite of block manager blklist, to make it
more readable and perhaps even faster.
Tested on Win64(wine) and Linux32/64 (also tested it doesn't break
android arm64 since it changes some stuff there too).