### PR TITLE
Add social tab, buttons, cta

### DIFF
--- a/core/linux-dist/main.cpp
+++ b/core/linux-dist/main.cpp
@@ -151,6 +151,12 @@ void os_SetWindowText(const char * text)
 	#endif
 }
 
+void os_LaunchFromURL(const string& url)
+{
+	auto cmd = "xdg-open " + url; 
+	system(cmd.c_str());
+}
+
 void os_CreateWindow()
 {
 	#if defined(SUPPORT_DISPMANX)

--- a/core/nullDC.cpp
+++ b/core/nullDC.cpp
@@ -654,6 +654,8 @@ void LoadSettings(bool game_specific)
 	settings.omx.Audio_HDMI		= cfgLoadBool(game_specific ? cfgGetGameId() : "omx", "audio_hdmi", settings.omx.Audio_HDMI);
 #endif
 
+	settings.social.HideCallToAction = cfgLoadBool(config_section, "Social.HideCallToAction", settings.social.HideCallToAction);
+	
 	if (!game_specific)
 	{
 		settings.dreamcast.ContentPath.clear();
@@ -787,6 +789,8 @@ void SaveSettings()
 	cfgSaveStr("config", "Dreamcast.ContentPath", paths.c_str());
 
 	GamepadDevice::SaveMaplePorts();
+
+	cfgSaveBool("config", "Social.HideCallToAction", settings.social.HideCallToAction);
 
 #ifdef _ANDROID
 	void SaveAndroidSettings();

--- a/core/oslib/oslib.h
+++ b/core/oslib/oslib.h
@@ -29,3 +29,5 @@ u32 static INLINE bitscanrev(u32 v)
 #define __assume(x)
 
 void os_DebugBreak();
+
+void os_LaunchFromURL(const string& url);

--- a/core/rend/gui.cpp
+++ b/core/rend/gui.cpp
@@ -1208,6 +1208,42 @@ static void gui_display_settings()
 			ImGui::PopStyleVar();
 			ImGui::EndTabItem();
 		}
+		
+		if (ImGui::BeginTabItem("Social"))
+		{
+			ImGui::Checkbox("Hide Social links from games list", &settings.social.HideCallToAction);
+		
+			ImGui::Separator();
+
+			if (ImGui::Button("Donate / Support Reicast (via emudev.org)")) {
+		    	os_LaunchFromURL("http://donate.emudev.org");
+		    }
+
+			if (ImGui::Button("Patreon (emudev.org)")) {
+		    	os_LaunchFromURL("http://patreon.emudev.org");
+		    }
+
+			ImGui::Separator();
+
+			if (ImGui::Button("Discord")) {
+		    	os_LaunchFromURL("http://chat.reicast.com");
+		    }
+
+			if (ImGui::Button("Facebook")) {
+		    	os_LaunchFromURL("http://facebook.com/reicastdc");
+		    }
+
+			if (ImGui::Button("Twitter")) {
+		    	os_LaunchFromURL("https://twitter.com/reicastdc");
+		    }
+
+			if (ImGui::Button("Homepage")) {
+		    	os_LaunchFromURL("http://reicast.com");
+		    }
+
+			ImGui::EndTabItem();
+		}
+
 		if (ImGui::BeginTabItem("About"))
 		{
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, normal_padding);
@@ -1448,6 +1484,18 @@ static void gui_display_content()
     {
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8 * scaling, 20 * scaling));		// from 8, 4
 
+		if (!settings.social.HideCallToAction)
+		{
+			ImGui::PushID("discord");
+			if (ImGui::Selectable("Join our Discord Server!"))
+			{
+				os_LaunchFromURL("http://chat.reicast.com");
+			}
+			ImGui::PopID();	
+
+			ImGui::Separator();
+		}
+		
 #if DC_PLATFORM == DC_PLATFORM_DREAMCAST
 		ImGui::PushID("bios");
 		if (ImGui::Selectable("Dreamcast BIOS"))

--- a/core/types.h
+++ b/core/types.h
@@ -738,6 +738,12 @@ struct settings_t
 		int maple_expansion_devices[4][2];
 		int VirtualGamepadVibration;
 	} input;
+
+
+	struct {
+		bool HideCallToAction;
+	} social;
+
 };
 
 extern settings_t settings;

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -15,6 +15,8 @@
 #include "hw/maple/maple_cfg.h"
 #pragma comment(lib, "XInput9_1_0.lib")
 
+#include <process.h>
+
 PCHAR*
 	CommandLineToArgvA(
 	PCHAR CmdLine,
@@ -810,3 +812,9 @@ void os_DoEvents()
 
 int get_mic_data(u8* buffer) { return 0; }
 int push_vmu_screen(u8* buffer) { return 0; }
+
+void os_LaunchFromURL(const string& url)
+{
+	auto cmd = "start " + url; 
+	system(cmd.c_str());
+}

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -815,6 +815,5 @@ int push_vmu_screen(u8* buffer) { return 0; }
 
 void os_LaunchFromURL(const string& url)
 {
-	auto cmd = "start " + url; 
-	system(cmd.c_str());
+	ShellExecuteA((HWND)window_win, "open", url.c_str(), nullptr, nullptr, SW_SHOW);
 }

--- a/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
+++ b/shell/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
@@ -6,6 +6,8 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
+import android.net.Uri;
+import android.content.Intent;
 
 import com.reicast.emulator.config.Config;
 import com.reicast.emulator.emu.AudioBackend;
@@ -65,6 +67,11 @@ public class Emulator extends Application {
         if (micPluggedIn() && currentActivity instanceof BaseGLActivity) {
             ((BaseGLActivity)currentActivity).requestRecordAudioPermission();
         }
+    }
+
+    public void LaunchFromUrl(String url) {
+        Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        startActivity(i);
     }
 
     public static boolean micPluggedIn() {

--- a/shell/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/shell/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -156,6 +156,7 @@ extern bool print_stats;
 //stuff for saving prefs
 jobject g_emulator;
 jmethodID saveAndroidSettingsMid;
+jmethodID launchFromUrlMid;
 static ANativeWindow *g_window = 0;
 
 void os_DoEvents()
@@ -217,6 +218,7 @@ JNIEXPORT jstring JNICALL Java_com_reicast_emulator_emu_JNIdc_initEnvironment(JN
     if (g_emulator == NULL) {
         g_emulator = env->NewGlobalRef(emulator);
         saveAndroidSettingsMid = env->GetMethodID(env->GetObjectClass(emulator), "SaveAndroidSettings", "(Ljava/lang/String;)V");
+        launchFromUrlMid  = env->GetMethodID(env->GetObjectClass(emulator), "LaunchFromUrl", "(Ljava/lang/String;)V");
     }
     // Set home directory based on User config
     const char* path = homeDirectory != NULL ? env->GetStringUTFChars(homeDirectory, 0) : "";
@@ -604,6 +606,14 @@ void SaveAndroidSettings()
 
     jvm_attacher.getEnv()->CallVoidMethod(g_emulator, saveAndroidSettingsMid, homeDirectory);
     jvm_attacher.getEnv()->DeleteLocalRef(homeDirectory);
+}
+
+void os_LaunchFromURL(const string& url)
+{
+    jstring jurl = jvm_attacher.getEnv()->NewStringUTF(url.c_str());
+
+    jvm_attacher.getEnv()->CallVoidMethod(g_emulator, launchFromUrlMid, jurl);
+    jvm_attacher.getEnv()->DeleteLocalRef(jurl);
 }
 
 JNIEXPORT void JNICALL Java_com_reicast_emulator_periph_InputDeviceManager_init(JNIEnv *env, jobject obj)


### PR DESCRIPTION
Quick and dirty social tab, discord CTA in games list

Windows and android haven't been tested, hopefully they build.

@davidgfnet can we handle this in switch too?

![reicast-cta-draft](https://user-images.githubusercontent.com/393266/59237924-b3741d80-8c04-11e9-9ed5-6d2ee9598ac8.png)
![reicast-social-draft](https://user-images.githubusercontent.com/393266/59237925-b40cb400-8c04-11e9-90f7-9ec247d26ad4.png)
