### PR TITLE
JIT: Add selective block discards

### DIFF
--- a/core/hw/mem/_vmem.cpp
+++ b/core/hw/mem/_vmem.cpp
@@ -419,7 +419,7 @@ void _vmem_bm_reset() {
 // This gets called whenever there is a pagefault, it is possible that it lands
 // on the fpcb memory range, which is allocated on miss. Returning true tells the
 // fault handler this was us, and that the page is resolved and can continue the execution.
-bool BM_LockedWrite(u8* address) {
+bool _vmem_bm_LockedWrite(u8* address) {
 	if (!virt_ram_base)
 		return false;  // No vmem, therefore not us who caused this.
 

--- a/core/hw/mem/_vmem.h
+++ b/core/hw/mem/_vmem.h
@@ -106,3 +106,4 @@ static inline bool _nvmem_enabled() {
 }
 
 void _vmem_bm_reset();
+bool _vmem_bm_LockedWrite(u8* address);

--- a/core/hw/sh4/dyna/blockmanager-extras.cpp
+++ b/core/hw/sh4/dyna/blockmanager-extras.cpp
@@ -1,0 +1,384 @@
+#if 0
+
+
+bool UDgreaterX ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
+{	
+	return elem1->runs > elem2->runs;
+}
+
+bool UDgreaterLOC ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
+{	
+	return elem1->addr < elem2->addr;
+}
+
+u32 FindPath(RuntimeBlockInfo* rbi, u32 sa,s32 mc,u32& plc)
+{
+	if (mc < 0 || rbi==0)
+		return 0;
+
+	plc++;
+	if (rbi->BlockType==BET_Cond_0 || rbi->BlockType==BET_Cond_1)
+	{
+		u32 plc1=plc,plc2=plc,v1=0,v2=0;
+		if (rbi->BranchBlock>sa)
+		{
+			v1=FindPath(bm_GetBlock(rbi->BranchBlock),rbi->addr,mc-rbi->guest_cycles,plc1);
+		}
+		v2=FindPath(bm_GetBlock(rbi->NextBlock),rbi->addr,mc-rbi->guest_cycles,plc2);
+		if (plc1>plc2)
+		{
+			plc=plc1;
+			return rbi->guest_cycles+v1;
+		}
+		else
+		{
+			plc=plc2;
+			return rbi->guest_cycles+v2;
+		}
+		
+	}
+	else if (rbi->BlockType==BET_StaticJump)
+	{
+		if (rbi->BranchBlock>sa)
+			return rbi->guest_cycles+FindPath(bm_GetBlock(rbi->BranchBlock),rbi->addr,mc-rbi->guest_cycles,plc);
+		else
+		{
+			return rbi->guest_cycles;
+		}
+	}
+	else
+	{
+		if (plc!=1)
+			printf("Chain lost due to %d\n",rbi->BlockType);
+		else
+			printf("Chain fail due to %d\n",rbi->BlockType);
+		return rbi->guest_cycles;
+	}
+}
+u32 total_saved;
+void FindPath(u32 start)
+{
+	RuntimeBlockInfo* rbi=bm_GetBlock(start);
+
+	if (!rbi || !rbi->runs)
+		return;
+
+	u32 plen=0;
+	u32 pclc=FindPath(rbi,start,SH4_TIMESLICE,plen);
+	if (plen>1)
+	{
+		total_saved+=(plen-1)*2*rbi->runs;
+		printf("%08X: %d, %d, %.2f, %.2f\n",start,pclc,plen,pclc/(float)plen,plen*2*rbi->runs/1000.f);
+	}
+	rbi->runs=0;
+}
+
+
+u32 rebuild_counter=20;
+void bm_Periodical_1s()
+{
+	for (u32 i=0;i<del_blocks.size();i++)
+		delete del_blocks[i];
+
+	del_blocks.clear();
+
+	if (rebuild_counter>0) rebuild_counter--;
+#if HOST_OS==OS_WINDOWS && 0
+	std::sort(all_blocks.begin(),all_blocks.end(),UDgreaterX);
+
+	map<u32,u32> vmap;
+	map<u32,u32> calls;
+
+	u32 total_runs=0;
+	for(int i=0;i<all_blocks.size();i++)
+	{
+		RuntimeBlockInfo* rbi=all_blocks[i];
+		total_runs+=rbi->runs;
+		if (rbi->BranchBlock!=-1 && rbi->BranchBlock < rbi->addr)
+		{
+			if (rbi->BlockType==BET_Cond_0 || rbi->BlockType==BET_Cond_1 || rbi->BlockType==BET_StaticJump)
+			{
+				RuntimeBlockInfo* bbi=bm_GetBlock(all_blocks[i]->BranchBlock);
+				if (bbi && bbi->runs)
+				{
+					vmap[all_blocks[i]->BranchBlock]=bbi->runs;
+				}
+			}
+
+			if (rbi->BlockType==BET_StaticCall)
+			{
+				RuntimeBlockInfo* bbi=bm_GetBlock(all_blocks[i]->BranchBlock);
+				if (bbi && bbi->runs)
+				{
+					calls[all_blocks[i]->BranchBlock]+=rbi->runs;
+				}
+			}
+		}
+		verify(rbi->NextBlock>rbi->addr);
+	}
+
+	map<u32,u32>::iterator iter=vmap.begin();
+
+	total_saved=0;
+	u32 total_l_runs=0;
+	while(iter!=vmap.end())
+	{
+		FindPath(iter->first);
+		total_l_runs+=iter->second;
+		iter++;
+	}
+
+	for(int i=0;i<all_blocks.size();i++)
+		all_blocks[i]->runs=0;
+
+	printf("Total Saved: %.2f || Total Loop Runs: %.2f  || Total Runs: %.2f\n",total_saved/1000.f,total_l_runs/1000.f,total_runs/1000.f);
+#endif
+}
+
+
+void constprop(RuntimeBlockInfo* blk);
+void bm_Rebuild()
+{
+	return;
+
+	die("this is broken in multiple levels, including compile options");
+
+	void RASDASD();
+	RASDASD();
+
+	blkmap.clear();
+	
+	std::sort(all_blocks.begin(),all_blocks.end(),UDgreaterLOC);
+	
+	for(size_t i=0; i<all_blocks.size(); i++)
+	{
+		bool do_opts=((all_blocks[i]->addr&0x3FFFFFFF)>0x0C010100);
+
+		if (all_blocks[i]->staging_runs<0 && do_opts)
+		{
+//#if HOST_OS==OS_WINDOWS
+			//constprop(all_blocks[i]);
+//#endif
+		}
+		ngen_Compile(all_blocks[i],NoCheck,false,all_blocks[i]->staging_runs>0,do_opts);
+
+		blkmap.insert(all_blocks[i]);
+		verify(bm_GetBlock((RuntimeBlockInfo*)all_blocks[i]->code)==all_blocks[i]);
+
+		FPCA(all_blocks[i]->addr)=all_blocks[i]->code;
+	}
+
+	for(size_t i=0; i<all_blocks.size(); i++)
+	{
+		all_blocks[i]->Relink();
+	}
+
+	rebuild_counter=30;
+}
+
+// BM extras
+void bm_WriteBlockMap(const string& file)
+{
+	FILE* f=fopen(file.c_str(),"wb");
+	if (f)
+	{
+		printf("Writing block map !\n");
+		for (size_t i=0; i<all_blocks.size(); i++)
+		{
+			fprintf(f,"block: %d:%08X:%p:%d:%d:%d\n",all_blocks[i]->BlockType,all_blocks[i]->addr,all_blocks[i]->code,all_blocks[i]->host_code_size,all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes);
+			for(size_t j=0;j<all_blocks[i]->oplist.size();j++)
+				fprintf(f,"\top: %zd:%d:%s\n",j,all_blocks[i]->oplist[j].guest_offs,all_blocks[i]->oplist[j].dissasm().c_str());
+		}
+		fclose(f);
+		printf("Finished writing block map\n");
+	}
+}
+
+u32 GetLookup(RuntimeBlockInfo* elem)
+{
+	return elem->lookups;
+}
+
+bool UDgreater ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
+{
+	return elem1->runs > elem2->runs;
+}
+
+bool UDgreater2 ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
+{
+	return elem1->runs*elem1->host_opcodes > elem2->runs*elem2->host_opcodes;
+}
+
+bool UDgreater3 ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
+{
+	return elem1->runs*elem1->host_opcodes/elem1->guest_cycles > elem2->runs*elem2->host_opcodes/elem2->guest_cycles;
+}
+
+void sh4_jitsym(FILE* out)
+{
+	for (size_t i=0; i<all_blocks.size(); i++)
+	{
+		fprintf(out,"%p %d %08X\n",all_blocks[i]->code,all_blocks[i]->host_code_size,all_blocks[i]->addr);
+	}
+}
+
+void bm_PrintTopBlocks()
+{
+	double total_lups=0;
+	double total_runs=0;
+	double total_cycles=0;
+	double total_hops=0;
+	double total_sops=0;
+
+	for (size_t i=0;i<all_blocks.size();i++)
+	{
+		total_lups+=GetLookup(all_blocks[i]);
+		total_cycles+=all_blocks[i]->runs*all_blocks[i]->guest_cycles;
+		total_hops+=all_blocks[i]->runs*all_blocks[i]->host_opcodes;
+		total_sops+=all_blocks[i]->runs*all_blocks[i]->guest_opcodes;
+		total_runs+=all_blocks[i]->runs;
+	}
+
+	printf("Total lookups:  %.0fKRuns, %.0fKLuops, Total cycles: %.0fMhz, Total Hops: %.0fMips, Total Sops: %.0fMips! \n",total_runs/1000,total_lups/1000,total_cycles/1000/1000,total_hops/1000/1000,total_sops/1000/1000);
+	total_hops/=100;
+	total_cycles/=100;
+	total_runs/=100;
+
+	double sel_hops=0;
+	for (size_t i=0;i<(all_blocks.size()/100);i++)
+	{
+		printf("Block %08X: %p, r: %d (c: %d, s: %d, h: %d) (r: %.2f%%, c: %.2f%%, h: %.2f%%)\n",
+			all_blocks[i]->addr, all_blocks[i]->code,all_blocks[i]->runs,
+			all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes,all_blocks[i]->host_opcodes,
+
+			all_blocks[i]->runs/total_runs,
+			all_blocks[i]->guest_cycles*all_blocks[i]->runs/total_cycles,
+			all_blocks[i]->host_opcodes*all_blocks[i]->runs/total_hops);
+		
+		sel_hops+=all_blocks[i]->host_opcodes*all_blocks[i]->runs;
+	}
+
+	printf(" >-< %.2f%% covered in top 1%% blocks\n",sel_hops/total_hops);
+
+	size_t i;
+	for (i=all_blocks.size()/100;sel_hops/total_hops<50;i++)
+	{
+		printf("Block %08X: %p, r: %d (c: %d, s: %d, h: %d) (r: %.2f%%, c: %.2f%%, h: %.2f%%)\n",
+			all_blocks[i]->addr, all_blocks[i]->code,all_blocks[i]->runs,
+			all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes,all_blocks[i]->host_opcodes,
+
+			all_blocks[i]->runs/total_runs,
+			all_blocks[i]->guest_cycles*all_blocks[i]->runs/total_cycles,
+			all_blocks[i]->host_opcodes*all_blocks[i]->runs/total_hops);
+		
+		sel_hops+=all_blocks[i]->host_opcodes*all_blocks[i]->runs;
+	}
+
+	printf(" >-< %.2f%% covered in top %.2f%% blocks\n",sel_hops/total_hops,i*100.0/all_blocks.size());
+
+}
+
+void bm_Sort()
+{
+	printf("!!!!!!!!!!!!!!!!!!! BLK REPORT !!!!!!!!!!!!!!!!!!!!n");
+
+	printf("     ---- Blocks: Sorted based on Runs ! ----     \n");
+	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater);
+	bm_PrintTopBlocks();
+
+	printf("<><><><><><><><><><><><><><><><><><><><><><><><><>\n");
+
+	printf("     ---- Blocks: Sorted based on hops ! ----     \n");
+	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater2);
+	bm_PrintTopBlocks();
+
+	printf("<><><><><><><><><><><><><><><><><><><><><><><><><>\n");
+
+	printf("     ---- Blocks: Sorted based on wefs ! ----     \n");
+	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater3);
+	bm_PrintTopBlocks();
+
+	printf("^^^^^^^^^^^^^^^^^^^ END REPORT ^^^^^^^^^^^^^^^^^^^\n");
+
+	for (size_t i=0;i<all_blocks.size();i++)
+	{
+		all_blocks[i]->runs=0;
+	}
+}
+
+
+void print_blocks()
+{
+	FILE* f=0;
+
+	if (print_stats)
+	{
+		f=fopen(get_writable_data_path("/blkmap.lst").c_str(),"w");
+		print_stats=0;
+
+		printf("Writing blocks to %p\n",f);
+	}
+
+	for (size_t i=0;i<all_blocks.size();i++)
+	{
+		RuntimeBlockInfo* blk=all_blocks[i];
+
+		if (f)
+		{
+			fprintf(f,"block: %p\n",blk);
+			fprintf(f,"addr: %08X\n",blk->addr);
+			fprintf(f,"hash: %s\n",blk->hash());
+			fprintf(f,"hash_rloc: %s\n",blk->hash(false,true));
+			fprintf(f,"code: %p\n",blk->code);
+			fprintf(f,"runs: %d\n",blk->runs);
+			fprintf(f,"BlockType: %d\n",blk->BlockType);
+			fprintf(f,"NextBlock: %08X\n",blk->NextBlock);
+			fprintf(f,"BranchBlock: %08X\n",blk->BranchBlock);
+			fprintf(f,"pNextBlock: %p\n",blk->pNextBlock);
+			fprintf(f,"pBranchBlock: %p\n",blk->pBranchBlock);
+			fprintf(f,"guest_cycles: %d\n",blk->guest_cycles);
+			fprintf(f,"guest_opcodes: %d\n",blk->guest_opcodes);
+			fprintf(f,"host_opcodes: %d\n",blk->host_opcodes);
+			fprintf(f,"il_opcodes: %zd\n",blk->oplist.size());
+
+			u32 hcode=0;
+			s32 gcode=-1;
+			u8* pucode=(u8*)blk->code;
+
+			size_t j=0;
+			
+			fprintf(f,"{\n");
+			for (;j<blk->oplist.size();j++)
+			{
+				shil_opcode* op=&all_blocks[i]->oplist[j];
+				fprint_hex(f,"//h:",pucode,hcode,op->host_offs);
+
+				if (gcode!=op->guest_offs)
+				{
+					gcode=op->guest_offs;
+					u32 rpc=blk->addr+gcode;
+					u16 op=ReadMem16(rpc);
+
+					char temp[128];
+					OpDesc[op]->Disassemble(temp,rpc,op);
+
+					fprintf(f,"//g:%s\n",temp);
+				}
+
+				string s=op->dissasm();
+				fprintf(f,"//il:%d:%d:%s\n",op->guest_offs,op->host_offs,s.c_str());
+			}
+			
+			fprint_hex(f,"//h:",pucode,hcode,blk->host_code_size);
+
+			fprintf(f,"}\n");
+		}
+
+		all_blocks[i]->runs=0;
+	}
+
+	if (f) fclose(f);
+}
+
+
+#endif

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -4,6 +4,9 @@
 */
 
 #include <algorithm>
+#include <set>
+#include <map>
+
 #include "blockmanager.h"
 #include "ngen.h"
 
@@ -20,19 +23,13 @@
 #include "hw/sh4/sh4_mem.h"
 
 
-#if HOST_OS==OS_LINUX && defined(DYNA_OPROF)
-#include <opagent.h>
-op_agent_t          oprofHandle;
-#endif
-
 #if FEAT_SHREC != DYNAREC_NONE
 
 
-typedef vector<RuntimeBlockInfo*> bm_List;
+typedef set<RuntimeBlockInfo*> bm_List;
 
 bm_List all_blocks;
 bm_List del_blocks;
-#include <set>
 
 std::map<void*, RuntimeBlockInfo*> blkmap;
 u32 bm_gc_luc,bm_gcf_luc;
@@ -84,15 +81,20 @@ RuntimeBlockInfo* bm_GetBlock(void* dynarec_code)
 	return iter->second;
 }
 
+void bm_CleanupDeletedBlocks()
+{
+	for (auto it = del_blocks.begin(); it != del_blocks.end(); it++)
+		delete *it;
+
+	del_blocks.clear();
+}
+
 // Takes RX pointer and returns a RW pointer
 RuntimeBlockInfo* bm_GetStaleBlock(void* dynarec_code)
 {
 	void *dynarecrw = CC_RX2RW(dynarec_code);
-	for(u32 i=0;i<del_blocks.size();i++)
-	{
-		if (del_blocks[i]->contains_code((u8*)dynarecrw))
-			return del_blocks[i];
-	}
+	
+	bm_CleanupDeletedBlocks();
 
 	return 0;
 }
@@ -105,202 +107,16 @@ void bm_AddBlock(RuntimeBlockInfo* blk)
 		verify(false);
 	}
 	blkmap[(void*)blk->code] = blk;
-	all_blocks.push_back(blk);
+	all_blocks.insert(blk);
 
 	verify((void*)bm_GetCode(blk->addr)==(void*)ngen_FailedToFindBlock);
 	FPCA(blk->addr) = (DynarecCodeEntryPtr)CC_RW2RX(blk->code);
-
-#ifdef DYNA_OPROF
-	if (oprofHandle)
-	{
-		char fname[512];
-
-		sprintf(fname,"sh4:%08X,c:%d,s:%d,h:%d",blk->addr,blk->guest_cycles,blk->guest_opcodes,blk->host_opcodes);
-
-		if (op_write_native_code(oprofHandle, fname, (uint64_t)blk->code, (void*)blk->code, blk->host_code_size) != 0) 
-		{
-			printf("op_write_native_code error\n");
-		}
-	}
-#endif
-
 }
 
-bool UDgreaterX ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
-{	
-	return elem1->runs > elem2->runs;
-}
-
-bool UDgreaterLOC ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
-{	
-	return elem1->addr < elem2->addr;
-}
-
-u32 FindPath(RuntimeBlockInfo* rbi, u32 sa,s32 mc,u32& plc)
-{
-	if (mc < 0 || rbi==0)
-		return 0;
-
-	plc++;
-	if (rbi->BlockType==BET_Cond_0 || rbi->BlockType==BET_Cond_1)
-	{
-		u32 plc1=plc,plc2=plc,v1=0,v2=0;
-		if (rbi->BranchBlock>sa)
-		{
-			v1=FindPath(bm_GetBlock(rbi->BranchBlock),rbi->addr,mc-rbi->guest_cycles,plc1);
-		}
-		v2=FindPath(bm_GetBlock(rbi->NextBlock),rbi->addr,mc-rbi->guest_cycles,plc2);
-		if (plc1>plc2)
-		{
-			plc=plc1;
-			return rbi->guest_cycles+v1;
-		}
-		else
-		{
-			plc=plc2;
-			return rbi->guest_cycles+v2;
-		}
-		
-	}
-	else if (rbi->BlockType==BET_StaticJump)
-	{
-		if (rbi->BranchBlock>sa)
-			return rbi->guest_cycles+FindPath(bm_GetBlock(rbi->BranchBlock),rbi->addr,mc-rbi->guest_cycles,plc);
-		else
-		{
-			return rbi->guest_cycles;
-		}
-	}
-	else
-	{
-		if (plc!=1)
-			printf("Chain lost due to %d\n",rbi->BlockType);
-		else
-			printf("Chain fail due to %d\n",rbi->BlockType);
-		return rbi->guest_cycles;
-	}
-}
-u32 total_saved;
-void FindPath(u32 start)
-{
-	RuntimeBlockInfo* rbi=bm_GetBlock(start);
-
-	if (!rbi || !rbi->runs)
-		return;
-
-	u32 plen=0;
-	u32 pclc=FindPath(rbi,start,SH4_TIMESLICE,plen);
-	if (plen>1)
-	{
-		total_saved+=(plen-1)*2*rbi->runs;
-		printf("%08X: %d, %d, %.2f, %.2f\n",start,pclc,plen,pclc/(float)plen,plen*2*rbi->runs/1000.f);
-	}
-	rbi->runs=0;
-}
-
-#include <map>
-u32 rebuild_counter=20;
 void bm_Periodical_1s()
 {
-	for (u32 i=0;i<del_blocks.size();i++)
-		delete del_blocks[i];
-
-	del_blocks.clear();
-
-	if (rebuild_counter>0) rebuild_counter--;
-#if HOST_OS==OS_WINDOWS && 0
-	std::sort(all_blocks.begin(),all_blocks.end(),UDgreaterX);
-
-	map<u32,u32> vmap;
-	map<u32,u32> calls;
-
-	u32 total_runs=0;
-	for(int i=0;i<all_blocks.size();i++)
-	{
-		RuntimeBlockInfo* rbi=all_blocks[i];
-		total_runs+=rbi->runs;
-		if (rbi->BranchBlock!=-1 && rbi->BranchBlock < rbi->addr)
-		{
-			if (rbi->BlockType==BET_Cond_0 || rbi->BlockType==BET_Cond_1 || rbi->BlockType==BET_StaticJump)
-			{
-				RuntimeBlockInfo* bbi=bm_GetBlock(all_blocks[i]->BranchBlock);
-				if (bbi && bbi->runs)
-				{
-					vmap[all_blocks[i]->BranchBlock]=bbi->runs;
-				}
-			}
-
-			if (rbi->BlockType==BET_StaticCall)
-			{
-				RuntimeBlockInfo* bbi=bm_GetBlock(all_blocks[i]->BranchBlock);
-				if (bbi && bbi->runs)
-				{
-					calls[all_blocks[i]->BranchBlock]+=rbi->runs;
-				}
-			}
-		}
-		verify(rbi->NextBlock>rbi->addr);
-	}
-
-	map<u32,u32>::iterator iter=vmap.begin();
-
-	total_saved=0;
-	u32 total_l_runs=0;
-	while(iter!=vmap.end())
-	{
-		FindPath(iter->first);
-		total_l_runs+=iter->second;
-		iter++;
-	}
-
-	for(int i=0;i<all_blocks.size();i++)
-		all_blocks[i]->runs=0;
-
-	printf("Total Saved: %.2f || Total Loop Runs: %.2f  || Total Runs: %.2f\n",total_saved/1000.f,total_l_runs/1000.f,total_runs/1000.f);
-#endif
+	bm_CleanupDeletedBlocks();
 }
-
-#if 0
-void constprop(RuntimeBlockInfo* blk);
-void bm_Rebuild()
-{
-	return;
-
-	die("this is broken in multiple levels, including compile options");
-
-	void RASDASD();
-	RASDASD();
-
-	blkmap.clear();
-	
-	std::sort(all_blocks.begin(),all_blocks.end(),UDgreaterLOC);
-	
-	for(size_t i=0; i<all_blocks.size(); i++)
-	{
-		bool do_opts=((all_blocks[i]->addr&0x3FFFFFFF)>0x0C010100);
-
-		if (all_blocks[i]->staging_runs<0 && do_opts)
-		{
-//#if HOST_OS==OS_WINDOWS
-			//constprop(all_blocks[i]);
-//#endif
-		}
-		ngen_Compile(all_blocks[i],NoCheck,false,all_blocks[i]->staging_runs>0,do_opts);
-
-		blkmap.insert(all_blocks[i]);
-		verify(bm_GetBlock((RuntimeBlockInfo*)all_blocks[i]->code)==all_blocks[i]);
-
-		FPCA(all_blocks[i]->addr)=all_blocks[i]->code;
-	}
-
-	for(size_t i=0; i<all_blocks.size(); i++)
-	{
-		all_blocks[i]->Relink();
-	}
-
-	rebuild_counter=30;
-}
-#endif
 
 void bm_vmem_pagefill(void** ptr, u32 size_bytes)
 {
@@ -315,189 +131,31 @@ void bm_Reset()
 	ngen_ResetBlocks();
 	_vmem_bm_reset();
 
-	for (size_t i=0; i<all_blocks.size(); i++)
+	for (auto it=all_blocks.begin(); it!=all_blocks.end(); it++)
 	{
-		all_blocks[i]->relink_data=0;
-		all_blocks[i]->pNextBlock=0;
-		all_blocks[i]->pBranchBlock=0;
-		all_blocks[i]->Relink();
+		(*it)->relink_data=0;
+		(*it)->pNextBlock=0;
+		(*it)->pBranchBlock=0;
+		(*it)->Relink();
 	}
 
-	del_blocks.insert(del_blocks.begin(),all_blocks.begin(),all_blocks.end());
+	del_blocks.insert(all_blocks.begin(),all_blocks.end());
 
 	all_blocks.clear();
 	blkmap.clear();
-
-#ifdef DYNA_OPROF
-	if (oprofHandle)
-	{
-		for (int i=0;i<del_blocks.size();i++)
-		{
-			if (op_unload_native_code(oprofHandle, (uint64_t)del_blocks[i]->code) != 0)
-			{
-				printf("op_unload_native_code error\n");
-			}
-		}
-	}
-#endif
 }
 
 
 void bm_Init()
 {
 
-#ifdef DYNA_OPROF
-	oprofHandle=op_open_agent();
-	if (oprofHandle==0)
-		printf("bm: Failed to open oprofile\n");
-	else
-		printf("bm: Oprofile integration enabled !\n");
-#endif
 }
 
 void bm_Term()
 {
-#ifdef DYNA_OPROF
-	if (oprofHandle) op_close_agent(oprofHandle);
-	
-	oprofHandle=0;
-#endif
 	bm_Reset();
-	for (int i = 0; i < del_blocks.size(); i++)
-		delete del_blocks[i];
-	del_blocks.clear();
+	bm_CleanupDeletedBlocks();
 }
-
-void bm_WriteBlockMap(const string& file)
-{
-	FILE* f=fopen(file.c_str(),"wb");
-	if (f)
-	{
-		printf("Writing block map !\n");
-		for (size_t i=0; i<all_blocks.size(); i++)
-		{
-			fprintf(f,"block: %d:%08X:%p:%d:%d:%d\n",all_blocks[i]->BlockType,all_blocks[i]->addr,all_blocks[i]->code,all_blocks[i]->host_code_size,all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes);
-			for(size_t j=0;j<all_blocks[i]->oplist.size();j++)
-				fprintf(f,"\top: %zd:%d:%s\n",j,all_blocks[i]->oplist[j].guest_offs,all_blocks[i]->oplist[j].dissasm().c_str());
-		}
-		fclose(f);
-		printf("Finished writing block map\n");
-	}
-}
-
-u32 GetLookup(RuntimeBlockInfo* elem)
-{
-	return elem->lookups;
-}
-
-bool UDgreater ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
-{
-	return elem1->runs > elem2->runs;
-}
-
-bool UDgreater2 ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
-{
-	return elem1->runs*elem1->host_opcodes > elem2->runs*elem2->host_opcodes;
-}
-
-bool UDgreater3 ( RuntimeBlockInfo* elem1, RuntimeBlockInfo* elem2 )
-{
-	return elem1->runs*elem1->host_opcodes/elem1->guest_cycles > elem2->runs*elem2->host_opcodes/elem2->guest_cycles;
-}
-
-void sh4_jitsym(FILE* out)
-{
-	for (size_t i=0; i<all_blocks.size(); i++)
-	{
-		fprintf(out,"%p %d %08X\n",all_blocks[i]->code,all_blocks[i]->host_code_size,all_blocks[i]->addr);
-	}
-}
-
-void bm_PrintTopBlocks()
-{
-	double total_lups=0;
-	double total_runs=0;
-	double total_cycles=0;
-	double total_hops=0;
-	double total_sops=0;
-
-	for (size_t i=0;i<all_blocks.size();i++)
-	{
-		total_lups+=GetLookup(all_blocks[i]);
-		total_cycles+=all_blocks[i]->runs*all_blocks[i]->guest_cycles;
-		total_hops+=all_blocks[i]->runs*all_blocks[i]->host_opcodes;
-		total_sops+=all_blocks[i]->runs*all_blocks[i]->guest_opcodes;
-		total_runs+=all_blocks[i]->runs;
-	}
-
-	printf("Total lookups:  %.0fKRuns, %.0fKLuops, Total cycles: %.0fMhz, Total Hops: %.0fMips, Total Sops: %.0fMips! \n",total_runs/1000,total_lups/1000,total_cycles/1000/1000,total_hops/1000/1000,total_sops/1000/1000);
-	total_hops/=100;
-	total_cycles/=100;
-	total_runs/=100;
-
-	double sel_hops=0;
-	for (size_t i=0;i<(all_blocks.size()/100);i++)
-	{
-		printf("Block %08X: %p, r: %d (c: %d, s: %d, h: %d) (r: %.2f%%, c: %.2f%%, h: %.2f%%)\n",
-			all_blocks[i]->addr, all_blocks[i]->code,all_blocks[i]->runs,
-			all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes,all_blocks[i]->host_opcodes,
-
-			all_blocks[i]->runs/total_runs,
-			all_blocks[i]->guest_cycles*all_blocks[i]->runs/total_cycles,
-			all_blocks[i]->host_opcodes*all_blocks[i]->runs/total_hops);
-		
-		sel_hops+=all_blocks[i]->host_opcodes*all_blocks[i]->runs;
-	}
-
-	printf(" >-< %.2f%% covered in top 1%% blocks\n",sel_hops/total_hops);
-
-	size_t i;
-	for (i=all_blocks.size()/100;sel_hops/total_hops<50;i++)
-	{
-		printf("Block %08X: %p, r: %d (c: %d, s: %d, h: %d) (r: %.2f%%, c: %.2f%%, h: %.2f%%)\n",
-			all_blocks[i]->addr, all_blocks[i]->code,all_blocks[i]->runs,
-			all_blocks[i]->guest_cycles,all_blocks[i]->guest_opcodes,all_blocks[i]->host_opcodes,
-
-			all_blocks[i]->runs/total_runs,
-			all_blocks[i]->guest_cycles*all_blocks[i]->runs/total_cycles,
-			all_blocks[i]->host_opcodes*all_blocks[i]->runs/total_hops);
-		
-		sel_hops+=all_blocks[i]->host_opcodes*all_blocks[i]->runs;
-	}
-
-	printf(" >-< %.2f%% covered in top %.2f%% blocks\n",sel_hops/total_hops,i*100.0/all_blocks.size());
-
-}
-
-void bm_Sort()
-{
-	printf("!!!!!!!!!!!!!!!!!!! BLK REPORT !!!!!!!!!!!!!!!!!!!!n");
-
-	printf("     ---- Blocks: Sorted based on Runs ! ----     \n");
-	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater);
-	bm_PrintTopBlocks();
-
-	printf("<><><><><><><><><><><><><><><><><><><><><><><><><>\n");
-
-	printf("     ---- Blocks: Sorted based on hops ! ----     \n");
-	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater2);
-	bm_PrintTopBlocks();
-
-	printf("<><><><><><><><><><><><><><><><><><><><><><><><><>\n");
-
-	printf("     ---- Blocks: Sorted based on wefs ! ----     \n");
-	std::sort(all_blocks.begin(),all_blocks.end(),UDgreater3);
-	bm_PrintTopBlocks();
-
-	printf("^^^^^^^^^^^^^^^^^^^ END REPORT ^^^^^^^^^^^^^^^^^^^\n");
-
-	for (size_t i=0;i<all_blocks.size();i++)
-	{
-		all_blocks[i]->runs=0;
-	}
-}
-
-
 
 RuntimeBlockInfo::~RuntimeBlockInfo()
 {
@@ -538,79 +196,15 @@ void fprint_hex(FILE* d,const char* init,u8* ptr, u32& ofs, u32 limit)
 	fputs("\n",d);
 }
 
-
-
-void print_blocks()
+void bm_WriteBlockMap(const string& file)
 {
-	FILE* f=0;
-
-	if (print_stats)
-	{
-		f=fopen(get_writable_data_path("/blkmap.lst").c_str(),"w");
-		print_stats=0;
-
-		printf("Writing blocks to %p\n",f);
-	}
-
-	for (size_t i=0;i<all_blocks.size();i++)
-	{
-		RuntimeBlockInfo* blk=all_blocks[i];
-
-		if (f)
-		{
-			fprintf(f,"block: %p\n",blk);
-			fprintf(f,"addr: %08X\n",blk->addr);
-			fprintf(f,"hash: %s\n",blk->hash());
-			fprintf(f,"hash_rloc: %s\n",blk->hash(false,true));
-			fprintf(f,"code: %p\n",blk->code);
-			fprintf(f,"runs: %d\n",blk->runs);
-			fprintf(f,"BlockType: %d\n",blk->BlockType);
-			fprintf(f,"NextBlock: %08X\n",blk->NextBlock);
-			fprintf(f,"BranchBlock: %08X\n",blk->BranchBlock);
-			fprintf(f,"pNextBlock: %p\n",blk->pNextBlock);
-			fprintf(f,"pBranchBlock: %p\n",blk->pBranchBlock);
-			fprintf(f,"guest_cycles: %d\n",blk->guest_cycles);
-			fprintf(f,"guest_opcodes: %d\n",blk->guest_opcodes);
-			fprintf(f,"host_opcodes: %d\n",blk->host_opcodes);
-			fprintf(f,"il_opcodes: %zd\n",blk->oplist.size());
-
-			u32 hcode=0;
-			s32 gcode=-1;
-			u8* pucode=(u8*)blk->code;
-
-			size_t j=0;
-			
-			fprintf(f,"{\n");
-			for (;j<blk->oplist.size();j++)
-			{
-				shil_opcode* op=&all_blocks[i]->oplist[j];
-				fprint_hex(f,"//h:",pucode,hcode,op->host_offs);
-
-				if (gcode!=op->guest_offs)
-				{
-					gcode=op->guest_offs;
-					u32 rpc=blk->addr+gcode;
-					u16 op=ReadMem16(rpc);
-
-					char temp[128];
-					OpDesc[op]->Disassemble(temp,rpc,op);
-
-					fprintf(f,"//g:%s\n",temp);
-				}
-
-				string s=op->dissasm();
-				fprintf(f,"//il:%d:%d:%s\n",op->guest_offs,op->host_offs,s.c_str());
-			}
-			
-			fprint_hex(f,"//h:",pucode,hcode,blk->host_code_size);
-
-			fprintf(f,"}\n");
-		}
-
-		all_blocks[i]->runs=0;
-	}
-
-	if (f) fclose(f);
+	die("bm_WriteBlockMap is noop");
 }
+
+void bm_sh4_jitsym(FILE* out)
+{
+	die("bm_sh4_jitsym is noop");
+}
+
 #endif
 

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -129,7 +129,7 @@ void bm_DiscardBlock(RuntimeBlockInfo* blk)
 	del_blocks.insert(blk);
 
 	verify((void*)bm_GetCode(blk->addr)==(void*)blk->code);
-	FPCA(blk->addr) = (DynarecCodeEntryPtr)&ngen_FailedToFindBlock;
+	FPCA(blk->addr) = (DynarecCodeEntryPtr)ngen_FailedToFindBlock;
 	verify((void*)bm_GetCode(blk->addr)==(void*)ngen_FailedToFindBlock);
 }
 
@@ -205,7 +205,23 @@ void RuntimeBlockInfo::RemRef(RuntimeBlockInfo* other)
 
 void RuntimeBlockInfo::Discard()
 {
-	die("Discard not implemented");
+	for (auto it = pre_refs.begin(); it != pre_refs.end(); it++)
+	{
+		if ((*it)->pBranchBlock == this)
+		{
+			(*it)->pBranchBlock = nullptr;
+		}
+
+		if ((*it)->pNextBlock == this)
+		{
+			(*it)->pNextBlock = nullptr;
+		}
+
+		(*it)->RemRef(this);
+
+		(*it)->Relink();
+	}
+	//die("Discard not implemented");
 }
 
 bool print_stats;

--- a/core/hw/sh4/dyna/blockmanager.cpp
+++ b/core/hw/sh4/dyna/blockmanager.cpp
@@ -133,6 +133,17 @@ void bm_DiscardBlock(RuntimeBlockInfo* blk)
 	verify((void*)bm_GetCode(blk->addr)==(void*)ngen_FailedToFindBlock);
 }
 
+void bm_DiscardAddress(u32 codeaddr)
+{
+	for (auto it=all_blocks.begin(); it!=all_blocks.end(); it++)
+	{
+		if ( ((*it)->addr <= codeaddr) && ((*it)->addr + (*it)->sh4_code_size) > codeaddr )
+		{
+			bm_DiscardBlock(*it);
+		}
+	}
+}
+
 void bm_Periodical_1s()
 {
 	bm_CleanupDeletedBlocks();

--- a/core/hw/sh4/dyna/blockmanager.h
+++ b/core/hw/sh4/dyna/blockmanager.h
@@ -110,3 +110,5 @@ void bm_Init();
 void bm_Term();
 
 void bm_vmem_pagefill(void** ptr,u32 PAGE_SZ);
+
+void bm_sh4_jitsym(FILE* out);

--- a/core/hw/sh4/dyna/blockmanager.h
+++ b/core/hw/sh4/dyna/blockmanager.h
@@ -101,6 +101,8 @@ RuntimeBlockInfo* bm_GetStaleBlock(void* dynarec_code);
 RuntimeBlockInfo* DYNACALL bm_GetBlock(u32 addr);
 
 void bm_AddBlock(RuntimeBlockInfo* blk);
+void bm_DiscardBlock(RuntimeBlockInfo* blk);
+
 void bm_Reset();
 void bm_Periodical_1s();
 void bm_Periodical_14k();

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -234,10 +234,10 @@ DynarecCodeEntryPtr rdv_CompilePC()
 {
 	u32 pc=next_pc;
 
-/*
+
 	if (emit_FreeSpace()<16*1024 || pc==0x8c0000e0 || pc==0xac010000 || pc==0xac008300)
 		recSh4_ClearCache();
-*/
+
 	RuntimeBlockInfo* rv=0;
 	do
 	{

--- a/core/hw/sh4/dyna/driver.cpp
+++ b/core/hw/sh4/dyna/driver.cpp
@@ -234,9 +234,10 @@ DynarecCodeEntryPtr rdv_CompilePC()
 {
 	u32 pc=next_pc;
 
+/*
 	if (emit_FreeSpace()<16*1024 || pc==0x8c0000e0 || pc==0xac010000 || pc==0xac008300)
 		recSh4_ClearCache();
-
+*/
 	RuntimeBlockInfo* rv=0;
 	do
 	{
@@ -305,7 +306,11 @@ u32 DYNACALL rdv_DoInterrupts(void* block_cpde)
 DynarecCodeEntryPtr DYNACALL rdv_BlockCheckFail(u32 pc)
 {
 	next_pc=pc;
-	recSh4_ClearCache();
+	auto block = bm_GetBlock(pc);
+
+	printf("Discard: %08X, %p\n", pc, block);
+
+	bm_DiscardBlock(block);
 	return (DynarecCodeEntryPtr)CC_RW2RX(rdv_CompilePC());
 }
 

--- a/core/hw/sh4/dyna/ngen.h
+++ b/core/hw/sh4/dyna/ngen.h
@@ -131,3 +131,6 @@ RuntimeBlockInfo* ngen_AllocateBlock();
 #ifdef __cplusplus
 }
 #endif
+
+bool ngen_Rewrite(unat& addr,unat retadr,unat acc);
+u32* ngen_readm_fail_v2(u32* ptr,u32* regs,u32 saddr);

--- a/core/linux/common.cpp
+++ b/core/linux/common.cpp
@@ -29,12 +29,10 @@
 #include "linux/context.h"
 
 #include "hw/sh4/dyna/ngen.h"
+#include "hw/mem/_vmem.h"
+#include "rend/TexCache.h"
 
 #if !defined(TARGET_NO_EXCEPTIONS)
-bool ngen_Rewrite(unat& addr,unat retadr,unat acc);
-u32* ngen_readm_fail_v2(u32* ptr,u32* regs,u32 saddr);
-bool VramLockedWrite(u8* address);
-bool BM_LockedWrite(u8* address);
 
 #if HOST_OS == OS_DARWIN
 void sigill_handler(int sn, siginfo_t * si, void *segfault_ctx) {
@@ -61,7 +59,7 @@ void fault_handler (int sn, siginfo_t * si, void *segfault_ctx)
 
 	bool dyna_cde = ((unat)CC_RX2RW(ctx.pc) > (unat)CodeCache) && ((unat)CC_RX2RW(ctx.pc) < (unat)(CodeCache + CODE_SIZE));
 
-	if (VramLockedWrite((u8*)si->si_addr) || BM_LockedWrite((u8*)si->si_addr))
+	if (VramLockedWrite((u8*)si->si_addr) || _vmem_bm_LockedWrite((u8*)si->si_addr))
 		return;
 	#if FEAT_SHREC == DYNAREC_JIT
 		#if HOST_CPU==CPU_ARM

--- a/core/linux/nixprof/nixprof.cpp
+++ b/core/linux/nixprof/nixprof.cpp
@@ -228,8 +228,6 @@ static int str_ends_with(const char * str, const char * suffix)
 	return 0 == strncmp(str + str_len - suffix_len, suffix, suffix_len);
 }
 
-void sh4_jitsym(FILE* out);
-
 static void* profiler_main(void *ptr)
 {
 	FILE* prof_out;
@@ -282,7 +280,7 @@ static void* profiler_main(void *ptr)
 		prof_head(prof_out, "jitsym", "SH4");
 		
 		#if FEAT_SHREC != DYNAREC_NONE
-		sh4_jitsym(prof_out);
+		bm_sh4_jitsym(prof_out);
 		#endif
 
 		//Write arm7rec syms file ! -> to do

--- a/core/rend/TexCache.h
+++ b/core/rend/TexCache.h
@@ -633,3 +633,4 @@ void vram_LockedWrite(u32 offset64);
 
 void DePosterize(u32* source, u32* dest, int width, int height);
 void UpscalexBRZ(int factor, u32* source, u32* dest, int width, int height, bool has_alpha);
+bool VramLockedWrite(u8* address);

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -17,6 +17,10 @@
 
 #include <process.h>
 
+#include "hw/sh4/dyna/ngen.h"
+#include "hw/mem/_vmem.h"
+#include "rend/TexCache.h"
+
 PCHAR*
 	CommandLineToArgvA(
 	PCHAR CmdLine,
@@ -113,9 +117,6 @@ PCHAR*
 
 void dc_exit(void);
 
-bool VramLockedWrite(u8* address);
-bool ngen_Rewrite(unat& addr,unat retadr,unat acc);
-bool BM_LockedWrite(u8* address);
 
 static std::shared_ptr<WinKbGamepadDevice> kb_gamepad;
 static std::shared_ptr<WinMouseGamepadDevice> mouse_gamepad;
@@ -151,7 +152,7 @@ LONG ExeptionHandler(EXCEPTION_POINTERS *ExceptionInfo)
 	{
 		return EXCEPTION_CONTINUE_EXECUTION;
 	}
-	else if (BM_LockedWrite(address))
+	else if (_vmem_bm_LockedWrite(address))
 	{
 		return EXCEPTION_CONTINUE_EXECUTION;
 	}

--- a/core/windows/winmain.cpp
+++ b/core/windows/winmain.cpp
@@ -1,7 +1,9 @@
+#define NOMINMAX 1
 
-#define _WIN32_WINNT 0x0502
 #include <windows.h>
 #include <windowsx.h>
+
+#include "rend/TexCache.h"
 
 #include "oslib/oslib.h"
 #include "oslib/audiostream.h"
@@ -11,15 +13,17 @@
 #include "xinput_gamepad.h"
 #include "win_keyboard.h"
 
-#include <xinput.h>
 #include "hw/maple/maple_cfg.h"
-#pragma comment(lib, "XInput9_1_0.lib")
 
 #include <process.h>
 
 #include "hw/sh4/dyna/ngen.h"
 #include "hw/mem/_vmem.h"
-#include "rend/TexCache.h"
+
+
+#include <xinput.h>
+#pragma comment(lib, "XInput9_1_0.lib")
+
 
 PCHAR*
 	CommandLineToArgvA(


### PR DESCRIPTION
- Will unlink blocks instead of full cache flush
  - Depends on `RBI:AddRef` and `RBI:RemRef` being called correctly
- Prevents stuttering on SMC
- Prerequisite for other aggressive optimizations
- Also moved some unused/debug code to `blockmanager-extras.cpp`
  - Will go over it when I revisit the tooling