### PR TITLE
segfault marshaling + cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(core_SRCS
   ${imgread_SRCS}
   ${profiler_SRCS}
   ${d_core}/archive/archive.cpp ${d_core}/archive/archive.h
-  ${d_core}/nullDC.cpp
+  ${d_core}/libswirl.cpp
   ${d_core}/stdclass.cpp
   ${d_core}/dispframe.cpp
   ${d_core}/serialize.cpp

--- a/libswirl/hw/holly/sb.cpp
+++ b/libswirl/hw/holly/sb.cpp
@@ -13,8 +13,7 @@
 #include "hw/modem/modem.h"
 
 #include "hw/naomi/naomi.h"
-
-extern void dc_request_reset();
+#include "libswirl.h"
 
 Array<RegisterStruct> sb_regs(0x540);
 

--- a/libswirl/hw/maple/maple_cfg.cpp
+++ b/libswirl/hw/maple/maple_cfg.cpp
@@ -5,6 +5,7 @@
 #include "maple_cfg.h"
 #include "cfg/cfg.h"
 #include "hw/naomi/naomi_cart.h"
+#include "oslib/oslib.h"
 
 #define HAS_VMU
 /*
@@ -22,7 +23,7 @@ Plugins:
 		InputUpdate(&fmt);
 		ImageUpdate(data);
 */
-void UpdateInputState(u32 port);
+
 void UpdateVibration(u32 port, float power, float inclination, u32 duration_ms);
 
 extern u16 kcode[4];

--- a/libswirl/hw/pvr/Renderer_if.h
+++ b/libswirl/hw/pvr/Renderer_if.h
@@ -63,3 +63,5 @@ typedef struct {
 } rendererbackend_t;
 extern bool RegisterRendererBackend(const rendererbackend_t& backend);
 vector<rendererbackend_t> rend_get_backends();
+
+void* rend_thread(void* p);

--- a/libswirl/hw/sh4/dyna/ngen.h
+++ b/libswirl/hw/sh4/dyna/ngen.h
@@ -44,6 +44,7 @@
 #include "rec_config.h"
 #include "decoder.h"
 #include "blockmanager.h"
+#include "oslib/context.h"
 
 
 #define CODE_SIZE   (10*1024*1024)
@@ -135,8 +136,7 @@ struct NGenBackend
 	// Alloc block, null return if out of blocks
 	virtual RuntimeBlockInfo* AllocateBlock() = 0;
 
-	virtual bool Rewrite(unat& addr, unat retadr, unat acc) = 0;
-	virtual u32* ReadmFail(u32* ptr, u32* regs, u32 saddr) = 0;
+	virtual bool Rewrite(rei_host_context_t* ctx) = 0;
 
 	// assembly exports
 

--- a/libswirl/jit/backend/arm32/rec_arm.cpp
+++ b/libswirl/jit/backend/arm32/rec_arm.cpp
@@ -2091,13 +2091,8 @@ struct Arm32NGenBackend: NGenBackend
 		printf("@@\tngen_ResetBlocks()\n");
 	}
 
-	bool Rewrite(unat& host_pc, unat, unat)
-	{
-		die("Not implemented");
-		return false;
-	}
-
-	u32* ReadmFail(u32* ptrv,u32* regs,u32 fault_addr)
+	
+	bool Rewrite(rei_host_context_t* ctx)
 	{
 		arm_mem_op* ptr=(arm_mem_op*)ptrv;
 
@@ -2252,7 +2247,9 @@ struct Arm32NGenBackend: NGenBackend
 		CacheFlush((void*)ptr, (void*)emit_ptr);
 		emit_ptr=0;
 
-		return (u32*)ptr;
+		//return (unat)ptr;
+
+		return true;
 	}
 
 	void CC_Start(shil_opcode* op) 

--- a/libswirl/jit/backend/arm32/rec_arm.cpp
+++ b/libswirl/jit/backend/arm32/rec_arm.cpp
@@ -2094,7 +2094,8 @@ struct Arm32NGenBackend: NGenBackend
 	
 	bool Rewrite(rei_host_context_t* ctx)
 	{
-		arm_mem_op* ptr=(arm_mem_op*)ptrv;
+		arm_mem_op* ptr=(arm_mem_op*)ctx->pc;
+		auto regs = ctx->regs;
 
 		verify(sizeof(*ptr)==4);
 
@@ -2149,7 +2150,7 @@ struct Arm32NGenBackend: NGenBackend
 
 		//get some other relevant data
 		u32 sh4_addr=regs[raddr];
-		u32 fault_offs=fault_addr-regs[8];
+		
 		u8* sh4_ctr=(u8*)regs[8];
 		bool is_sq=(sh4_addr>>26)==0x38;
 
@@ -2174,7 +2175,13 @@ struct Arm32NGenBackend: NGenBackend
 		//printf("Failed %08X:%08X (%d,%d,%d,r%d, r%d,f%d,d%d) code %08X, addr %08X, native %08X (%08X), fixing via %s\n",ptr->full,fop,optp,read,offs,raddr,rt,ft,fd,ptr,sh4_addr,fault_addr,fault_offs,is_sq?"SQ":"MR");
 
 		//fault offset must always be the addr from ubfx (sanity check)
-		verify((fault_offs==0) || fault_offs==(0x1FFFFFFF&sh4_addr));
+
+		// TODO: Reimplement this sanity check, it needs the fault mem address
+		
+		#if 0 && TODO
+			u32 fault_offs=fault_addr-regs[8];
+			verify((fault_offs==0) || fault_offs==(0x1FFFFFFF&sh4_addr));
+		#endif
 
 		if (settings.dynarec.unstable_opt && is_sq) //THPS2 uses cross area SZ_32F so this is disabled for now
 		{
@@ -2247,7 +2254,7 @@ struct Arm32NGenBackend: NGenBackend
 		CacheFlush((void*)ptr, (void*)emit_ptr);
 		emit_ptr=0;
 
-		//return (unat)ptr;
+		ctx->pc = (unat)ptr;
 
 		return true;
 	}

--- a/libswirl/jit/backend/arm64/rec_arm64.cpp
+++ b/libswirl/jit/backend/arm64/rec_arm64.cpp
@@ -1495,14 +1495,14 @@ struct Arm64NGenBackend: NGenBackend
 
 	}
 
-	bool Rewrite(unat& host_pc, unat, unat)
+	bool Rewrite(rei_host_context_t* ctx)
 	{
 		//printf("ngen_Rewrite pc %p\n", host_pc);
-		void *host_pc_rw = (void*)CC_RX2RW(host_pc);
-		RuntimeBlockInfo *block = bm_GetBlock((void*)host_pc);
+		void *host_pc_rw = (void*)CC_RX2RW(ctx->pc);
+		RuntimeBlockInfo *block = bm_GetBlock((void*)ctx->pc);
 		if (block == NULL)
 		{
-			printf("ngen_Rewrite: Block at %p not found\n", (void *)host_pc);
+			printf("ngen_Rewrite: Block at %p not found\n", (void *)ctx->pc);
 			return false;
 		}
 		u32 *code_ptr = (u32*)host_pc_rw;
@@ -1523,15 +1523,9 @@ struct Arm64NGenBackend: NGenBackend
 			assembler->GenWriteMemorySlow(op);
 		assembler->Finalize(true);
 		delete assembler;
-		host_pc = (unat)CC_RW2RX(code_ptr - 2);
+		ctx->pc = (unat)CC_RW2RX(code_ptr - 2);
 
 		return true;
-	}
-
-	u32* ReadmFail(u32* ptr, u32* regs, u32 saddr)
-	{
-		die("not implemented")
-		return nullptr;
 	}
 };
 

--- a/libswirl/jit/backend/cpp/rec_cpp.cpp
+++ b/libswirl/jit/backend/cpp/rec_cpp.cpp
@@ -1568,12 +1568,6 @@ struct CPPNGenBackend: NGenBackend
 		return new DynaRBI();
 	}
 
-	u32* ReadmFail(u32* ptr, u32* regs, u32 saddr)
-	{
-		die("Not implemented");
-		return nullptr;
-	}
-
 
 	void Compile(RuntimeBlockInfo* block, SmcCheckEnum smc_checks, bool reset, bool staging, bool optimise)
 	{
@@ -1587,7 +1581,7 @@ struct CPPNGenBackend: NGenBackend
 		delete compiler;
 	}
 
-	bool Rewrite(unat& host_pc, unat, unat)
+	bool Rewrite(rei_host_context_t* ctx)
 	{
 		die("Not implemented");
 		return false;

--- a/libswirl/jit/backend/x64/rec_x64.cpp
+++ b/libswirl/jit/backend/x64/rec_x64.cpp
@@ -1374,14 +1374,14 @@ struct X64NGenBackend : NGenBackend
 		delete compiler;
 	}
 
-	bool Rewrite(unat& host_pc, unat, unat)
+	bool Rewrite(rei_host_context_t* ctx)
 	{
 		//printf("ngen_Rewrite pc %p\n", host_pc);
-		void *host_pc_rw = (void*)CC_RX2RW(host_pc);
-		RuntimeBlockInfo *block = bm_GetBlock((void*)host_pc);
+		void *host_pc_rw = (void*)CC_RX2RW(ctx->pc);
+		RuntimeBlockInfo *block = bm_GetBlock((void*)ctx->pc);
 		if (block == NULL)
 		{
-			printf("ngen_Rewrite: Block at %p not found\n", (void *)host_pc);
+			printf("ngen_Rewrite: Block at %p not found\n", (void *)ctx->pc);
 			return false;
 		}
 		char *code_ptr = (char*)host_pc_rw;
@@ -1404,7 +1404,7 @@ struct X64NGenBackend : NGenBackend
 			comp.GenWriteMemorySlow(op, it->second.emitted_bytes);
 
 		// Move host_pc back N bytes to the begining of the whole load/store sequence.
-		host_pc = (unat)CC_RW2RX(rewrite_ptr);
+		ctx->pc = (unat)CC_RW2RX(rewrite_ptr);
 
 		return true;
 	}
@@ -1461,12 +1461,6 @@ struct X64NGenBackend : NGenBackend
 	RuntimeBlockInfo* AllocateBlock()
 	{
 		return new DynaRBI();
-	}
-
-	u32* ReadmFail(u32* ptr, u32* regs, u32 saddr)
-	{
-		die("Not implemented");
-		return nullptr;
 	}
 
 	void OnResetBlocks()

--- a/libswirl/jit/backend/x86/rec_x86_driver.cpp
+++ b/libswirl/jit/backend/x86/rec_x86_driver.cpp
@@ -849,7 +849,7 @@ struct X86NGenBackend : NGenBackend
 						#if HOST_OS == OS_LINUX
 							ctx->esp += 4;
 							//restore the addr from eax to ecx so it's valid again
-							ctx->ecx = ctx.eax;
+							ctx->ecx = ctx->eax;
 						#endif
 
 						//printf("Patched: %08X for access @ %08X\n",addr,acc);

--- a/libswirl/jit/backend/x86/rec_x86_driver.cpp
+++ b/libswirl/jit/backend/x86/rec_x86_driver.cpp
@@ -801,8 +801,14 @@ struct X86NGenBackend : NGenBackend
 	}
 
 
-	bool Rewrite(unat& addr,unat retadr,unat acc)
+	//bool Rewrite(unat& addr,unat retadr,unat acc)
+	bool Rewrite(rei_host_context_t* ctx)
 	{
+		auto& addr = ctx->pc;
+
+		u32 retadr = *(u32*)ctx->esp;
+		u32 acc = ctx->eax;
+
 		if (addr>=mem_code_base && addr<mem_code_end)
 		{
 			u32 ca=*(u32*)(retadr-4)+retadr;
@@ -840,6 +846,12 @@ struct X86NGenBackend : NGenBackend
 
 						addr=retadr-5;
 
+						#if HOST_OS == OS_LINUX
+							ctx->esp += 4;
+							//restore the addr from eax to ecx so it's valid again
+							ctx->ecx = ctx.eax;
+						#endif
+
 						//printf("Patched: %08X for access @ %08X\n",addr,acc);
 						return true;
 					}
@@ -854,12 +866,6 @@ struct X86NGenBackend : NGenBackend
 		{
 			return false;
 		}
-	}
-
-	u32* ReadmFail(u32* ptr, u32* regs, u32 saddr)
-	{
-		die("Not implemented");
-		return nullptr;
 	}
 
 	void OnResetBlocks()

--- a/libswirl/libswirl.cpp
+++ b/libswirl/libswirl.cpp
@@ -1,15 +1,15 @@
-// nullDC.cpp : Makes magic cookies
+// libswirl.cpp: this is not nullDC anymore. Not that anyone has noticed.
 //
 
 //initialse Emu
 #include "types.h"
+#include "libswirl.h"
 #include "oslib/oslib.h"
 #include "oslib/audiostream.h"
 #include "hw/mem/_vmem.h"
 #include "stdclass.h"
 #include "cfg/cfg.h"
 
-#include "types.h"
 #include "hw/maple/maple_cfg.h"
 #include "hw/sh4/sh4_mem.h"
 
@@ -26,8 +26,6 @@
 
 void FlushCache();
 void LoadCustom();
-void* dc_run(void*);
-void dc_resume();
 
 settings_t settings;
 // Set if game has corresponding option by default, so that it's not saved in the config

--- a/libswirl/libswirl.h
+++ b/libswirl/libswirl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "types.h"
+
+void dc_loadstate();
+void dc_savestate();
+void dc_stop();
+void dc_reset();
+void dc_resume();
+void dc_term();
+int dc_start_game(const char *path);
+
+void* dc_run(void*);
+
+void dc_request_reset();
+
+// TODO: rename these
+int reicast_init(int argc, char* argv[]);

--- a/libswirl/libswirl.h
+++ b/libswirl/libswirl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include "oslib/context.h"
 
 void dc_loadstate();
 void dc_savestate();
@@ -13,6 +14,8 @@ int dc_start_game(const char *path);
 void* dc_run(void*);
 
 void dc_request_reset();
+
+bool dc_handle_fault(unat addr, rei_host_context_t* ctx);
 
 // TODO: rename these
 int reicast_init(int argc, char* argv[]);

--- a/libswirl/linux-dist/main.cpp
+++ b/libswirl/linux-dist/main.cpp
@@ -16,6 +16,9 @@
 #include "hw/maple/maple_cfg.h"
 #include <unistd.h>
 
+#include "libswirl.h"
+#include "hw/pvr/Renderer_if.h"
+
 #if defined(TARGET_EMSCRIPTEN)
 	#include <emscripten.h>
 #endif
@@ -155,7 +158,7 @@ void os_SetWindowText(const char * text)
 void os_LaunchFromURL(const string& url)
 {
 	auto cmd = "xdg-open " + url; 
-	system(cmd.c_str());
+	auto rv = system(cmd.c_str());
 }
 
 void os_CreateWindow()
@@ -172,9 +175,6 @@ void os_CreateWindow()
 }
 
 void common_linux_setup();
-int reicast_init(int argc, char* argv[]);
-void dc_term();
-void* rend_thread(void* p);
 
 #ifdef TARGET_PANDORA
 

--- a/libswirl/linux/context.cpp
+++ b/libswirl/linux/context.cpp
@@ -35,19 +35,19 @@ void context_segfault(rei_host_context_t* reictx, void* segfault_ctx, bool to_se
 		bicopy(reictx->pc, MCTX(.__gregs[_REG_PC]), to_segfault);
 
 		for (int i = 0; i < 15; i++)
-			bicopy(reictx->r[i], MCTX(.__gregs[i]), to_segfault);
+			bicopy(reictx->regs[i], MCTX(.__gregs[i]), to_segfault);
 	#elif HOST_OS == OS_LINUX
 		bicopy(reictx->pc, MCTX(.arm_pc), to_segfault);
 		u32* r =(u32*) &MCTX(.arm_r0);
 
 		for (int i = 0; i < 15; i++)
-			bicopy(reictx->r[i], r[i], to_segfault);
+			bicopy(reictx->regs[i], r[i], to_segfault);
 
 	#elif HOST_OS == OS_DARWIN
 		bicopy(reictx->pc, MCTX(->__ss.__pc), to_segfault);
 
 		for (int i = 0; i < 15; i++)
-			bicopy(reictx->r[i], MCTX(->__ss.__r[i]), to_segfault);
+			bicopy(reictx->regs[i], MCTX(->__ss.__r[i]), to_segfault);
 	#else
 		#error HOST_OS
 	#endif

--- a/libswirl/linux/context.h
+++ b/libswirl/linux/context.h
@@ -2,20 +2,7 @@
 
 #include "types.h"
 
-
-struct rei_host_context_t {
-#if HOST_CPU != CPU_GENERIC
-	unat pc;
-#endif
-
-#if HOST_CPU == CPU_X86
-	u32 eax;
-	u32 ecx;
-	u32 esp;
-#elif HOST_CPU == CPU_ARM
-	u32 r[15];
-#endif
-};
+#include "oslib/context.h"
 
 void context_from_segfault(rei_host_context_t* reictx, void* segfault_ctx);
 void context_to_segfault(rei_host_context_t* reictx, void* segfault_ctx);

--- a/libswirl/oslib/context.h
+++ b/libswirl/oslib/context.h
@@ -11,6 +11,6 @@ struct rei_host_context_t {
 	u32 ecx;
 	u32 esp;
 #elif HOST_CPU == CPU_ARM
-	u32 r[15];
+	u32 regs[15];
 #endif
 };

--- a/libswirl/oslib/context.h
+++ b/libswirl/oslib/context.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "types.h"
+
+struct rei_host_context_t {
+#if HOST_CPU != CPU_GENERIC
+	unat pc;
+#endif
+
+#if HOST_CPU == CPU_X86
+	u32 eax;
+	u32 ecx;
+	u32 esp;
+#elif HOST_CPU == CPU_ARM
+	u32 r[15];
+#endif
+};

--- a/libswirl/oslib/oslib.h
+++ b/libswirl/oslib/oslib.h
@@ -35,3 +35,6 @@ void os_LaunchFromURL(const string& url);
 bool os_gl_init(void* hwnd, void* hdc);
 void os_gl_swap();
 void os_gl_term();
+
+// FIXME 2 - this needs to be os_*
+void UpdateInputState(u32 port);

--- a/libswirl/qt/main.cpp
+++ b/libswirl/qt/main.cpp
@@ -7,7 +7,9 @@
 #include "MainWindow.h"
 #include "VulkanWindow.h"
 
+#include "libswirl.h"
 #include "Renderer_if.h"
+
 
 void os_DoEvents();
 
@@ -38,12 +40,6 @@ int main(int argc, char* argv[])
 //#ifdef _WIN64
 //	setup_seh();
 //#endif
-
-	int reicast_init(int argc, char* argv[]);
-	void* rend_thread(void*);
-	void* dc_run(void*);
-	void dc_term();
-	int dc_start_game(const char* path);
 
 	set_user_data_dir( QString(QDir::currentPath()).toUtf8().cbegin() );	//  + "/data"  stupid data dir replication bs
 	set_user_config_dir("./");

--- a/libswirl/rend/gui.cpp
+++ b/libswirl/rend/gui.cpp
@@ -43,14 +43,8 @@
 #include "version.h"
 #include "oslib/audiostream.h"
 #include "hw/pvr/Renderer_if.h"
+#include "libswirl.h"
 
-extern void dc_loadstate();
-extern void dc_savestate();
-extern void dc_stop();
-extern void dc_reset();
-extern void dc_resume();
-extern int dc_start_game(const char *path);
-extern void UpdateInputState(u32 port);
 extern bool game_started;
 
 extern int screen_width, screen_height;

--- a/libswirl/windows/winmain.cpp
+++ b/libswirl/windows/winmain.cpp
@@ -303,47 +303,48 @@ LONG ExeptionHandler(EXCEPTION_POINTERS *ExceptionInfo)
 	if (dwCode != EXCEPTION_ACCESS_VIOLATION)
 		return EXCEPTION_CONTINUE_SEARCH;
 
-	u8* address=(u8*)pExceptionRecord->ExceptionInformation[1];
+	unat address=(unat)pExceptionRecord->ExceptionInformation[1];
 
-	//printf("[EXC] During access to : 0x%X\n", address);
+	rei_host_context_t ctx = { 0 };
 
-	if (VramLockedWrite(address))
-	{
-		return EXCEPTION_CONTINUE_EXECUTION;
-	}
-	else if (_vmem_bm_LockedWrite(address))
-	{
-		return EXCEPTION_CONTINUE_EXECUTION;
-	}
-	else if (bm_LockedWrite(address))
-	{
-		return EXCEPTION_CONTINUE_EXECUTION;
-	}
-#if FEAT_SHREC == DYNAREC_JIT
+	// TODO: Implement context abstraction for windows
 	#if HOST_CPU == CPU_X86
-		else if ( ngen_Rewrite((unat&)ep->ContextRecord->Eip,*(unat*)ep->ContextRecord->Esp,ep->ContextRecord->Eax) )
-		{
-			//remove the call from call stack
-			ep->ContextRecord->Esp+=4;
-			//restore the addr from eax to ecx so its valid again
-			ep->ContextRecord->Ecx=ep->ContextRecord->Eax;
-			return EXCEPTION_CONTINUE_EXECUTION;
-		}
+		ctx.pc = (unat&)ep->ContextRecord->Eip;
+
+		ctx.eax = (unat&)ep->ContextRecord->Eax;
+		ctx.ecx = (unat&)ep->ContextRecord->Ecx;
+		ctx.esp = (unat&)ep->ContextRecord->Esp;
+		
 	#elif HOST_CPU == CPU_X64
-		else if (rdv_ngen->Rewrite((unat&)ep->ContextRecord->Rip, 0, 0))
-		{
-			return EXCEPTION_CONTINUE_EXECUTION;
-		}
+		ctx.pc = (unat&)ep->ContextRecord->Rip;
+	#else
+		#error missing arch for windows
 	#endif
-#endif
+
+	if (dc_handle_fault(address, &ctx))
+	{
+		// TODO: Implement context abstraction for windows
+		#if HOST_CPU == CPU_X86
+			(unat&)ep->ContextRecord->Eip = ctx.pc;
+
+			(unat&)ep->ContextRecord->Eax = ctx.eax;
+			(unat&)ep->ContextRecord->Ecx = ctx.ecx;
+			(unat&)ep->ContextRecord->Esp = ctx.esp;
+			
+		#elif HOST_CPU == CPU_X64
+			(unat&)ep->ContextRecord->Rip = ctx.pc;
+		#else
+			#error missing arch for windows
+		#endif
+
+		return EXCEPTION_CONTINUE_EXECUTION;
+	}
 	else
 	{
-		//printf("[GPF]Unhandled access to : 0x%X\n",(unat)address);
+		//printf("[GPF] Unhandled access to : 0x%X\n",(unat)address);
+		return EXCEPTION_CONTINUE_SEARCH;
 	}
-
-	return EXCEPTION_CONTINUE_SEARCH;
 }
-
 
 void SetupPath()
 {

--- a/libswirl/windows/winmain.cpp
+++ b/libswirl/windows/winmain.cpp
@@ -25,6 +25,11 @@
 
 #include "glwrap/gl3w.h"
 
+
+#include "libswirl.h"
+#include "hw/pvr/Renderer_if.h"
+
+
 #undef ARRAY_SIZE	// macros are evil
 #pragma comment(lib,"Opengl32.lib")
 
@@ -898,10 +903,6 @@ int CALLBACK WinMain(HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine
 #endif
 	{
 		CoInitialize(nullptr);
-
-		int reicast_init(int argc, char* argv[]);
-		void *rend_thread(void *);
-		void dc_term();
 
 		if (reicast_init(argc, argv) != 0)
 			die("Reicast initialization failed");

--- a/reicast/android-studio/reicast/build.gradle
+++ b/reicast/android-studio/reicast/build.gradle
@@ -40,8 +40,6 @@ android {
             moduleName "dc"
                 abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
-
-        externalNativeBuild { ndkBuild { arguments "-j33" } }
     }
 
     signingConfigs {

--- a/reicast/android-studio/reicast/build.gradle
+++ b/reicast/android-studio/reicast/build.gradle
@@ -40,6 +40,8 @@ android {
             moduleName "dc"
                 abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
+
+        externalNativeBuild { ndkBuild { arguments "-j33" } }
     }
 
     signingConfigs {

--- a/reicast/android-studio/reicast/src/main/jni/src/Android.cpp
+++ b/reicast/android-studio/reicast/src/main/jni/src/Android.cpp
@@ -25,6 +25,7 @@
 #include "rend/gui.h"
 #include "cfg/cfg.h"
 
+#include "libswirl.h"
 JavaVM* g_jvm;
 
 // Convenience class to get the java environment for the current thread.
@@ -130,10 +131,6 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_screenDpi(JNIEnv *env
     screen_dpi = screenDpi;
 }
 
-int reicast_init(int argc, char* argv[]);
-void dc_resume();
-void dc_stop();
-void dc_term();
 
 bool egl_makecurrent();
 


### PR DESCRIPTION
- Rename `nulldc.cpp` to `libswirl.cpp`
- Create `libswirl.h` and move decls there
- Unify exception handling 
- Marshal segfaults for linux