### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 notifications:
   irc: chat.freenode.net#reicast
 language: android
+dist: trusty
 android:
   components:
   - platform-tools


### PR DESCRIPTION
Quickfix by using `dist: trusty`. We need a better long term fix.