### PR TITLE
egl: Fix gl4rend init

### DIFF
--- a/libswirl/utils/glinit/egl/egl.cpp
+++ b/libswirl/utils/glinit/egl/egl.cpp
@@ -118,10 +118,22 @@ bool egl_Init(void* wind, void* disp)
 		}
 		if (try_full_gl)
 		{
-			EGLint contextAttrs[] = { EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
-									  EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR,
+			EGLint contextAttrs[] = { EGL_CONTEXT_MAJOR_VERSION_KHR, 4,
+									  EGL_CONTEXT_MINOR_VERSION_KHR, 3,
+#ifndef NDEBUG
+									  EGL_CONTEXT_FLAGS_KHR, EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR,
+#endif
+									  EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR, EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT_KHR,
 									  EGL_NONE };
 			egl_setup.context = eglCreateContext(egl_setup.display, config, NULL, contextAttrs);
+			if (egl_setup.context == EGL_NO_CONTEXT) {
+				printf("EGL: Open GL 4.3 not supported\n");
+				// Try GL 3.0
+				contextAttrs[1] = 3;
+				contextAttrs[3] = 0;
+				egl_setup.context = eglCreateContext(egl_setup.display, config, NULL, contextAttrs);
+			}
+
 			if (egl_setup.context != EGL_NO_CONTEXT)
 			{
 				egl_MakeCurrent();


### PR DESCRIPTION
With the current context attributes, I am unable to use the "gl41" renderer with egl, it always fallback to the "gles". Because `EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT_KHR` is set for `EGL_CONTEXT_OPENGL_PROFILE_MASK_KHR` (+ with major version = 3 instead of 4), the following test failed:
https://github.com/reicast/reicast-emulator/blob/f6ddf0cedef83d51c911c262983580511ab02b01/libswirl/rend/gl4/gl4rend.cpp#L572-L574
`glGetIntegerv(GL_MAJOR_VERSION, &major);` and `glGetIntegerv(GL_MINOR_VERSION, &minor);` indicate a version equals to 3.0 whereas my graphic card is a 4.5.

I checked glx, sdl and wgl, none of them uses the compatibility profile for OpenGL:
https://github.com/reicast/reicast-emulator/blob/f205c0f53a821d31a4c39052b623e7393f96a20c/libswirl/utils/glinit/glx/glx.cpp#L96-L101
https://github.com/reicast/reicast-emulator/blob/f205c0f53a821d31a4c39052b623e7393f96a20c/libswirl/utils/glinit/sdl/sdl.cpp#L44-L46
https://github.com/reicast/reicast-emulator/blob/f205c0f53a821d31a4c39052b623e7393f96a20c/libswirl/utils/glinit/wgl/wgl.cpp#L131-L134

With the changes from this PR, it works. I also copied the fallback to OpenGL 3.0 from glx:
https://github.com/reicast/reicast-emulator/blob/f205c0f53a821d31a4c39052b623e7393f96a20c/libswirl/utils/glinit/glx/glx.cpp#L109-L113