### PR TITLE
pulseaudio: Add missing return value to the "push" function

### DIFF
--- a/libswirl/oslib/audiobackend_pulseaudio.cpp
+++ b/libswirl/oslib/audiobackend_pulseaudio.cpp
@@ -25,6 +25,7 @@ static u32 pulseaudio_push(void* frame, u32 samples, bool wait)
 	if (pa_simple_write(pulse_stream, frame, (size_t) samples*4, NULL) < 0) {
       fprintf(stderr, "PulseAudio: pa_simple_write() failed!\n");
 	}
+	return 0;
 }
 
 static void pulseaudio_term() {


### PR DESCRIPTION
Without this change, PulseAudio doesn't work for me.
Log before this change:
```
recSh4 Init
Using Interpreter
Sh4 Reset
Initializing audio backend "pulse" (PulseAudio)...
Using Interpreter
fault_handler: Blocking before restoring default SIGSEGV handler
PulseAudio: pa_simple_write() failed!
fault_handler: Blocking before restoring default SIGSEGV handler
fault_handler: Blocking before restoring default SIGSEGV handler
fault_handler: Blocking before restoring default SIGSEGV handler
```
Log after this change:
```
recSh4 Init
Using Interpreter
Sh4 Reset
Initializing audio backend "pulse" (PulseAudio)...
Using Interpreter
Invalid GD-DMA start, SB_GDEN=0.Ingoring it.
VREG = 03 ARMRST 00
VREG = 03 ARMRST 01
VREG = 03 ARMRST 00
Invalid GD-DMA start, SB_GDEN=0.Ingoring it.
VREG = 03 ARMRST 00
VREG = 03 ARMRST 01
VREG = 03 ARMRST 01
VREG = 03 ARMRST 00
Invalid GD-DMA start, SB_GDEN=0.Ingoring it.
VREG = 03 ARMRST 00
VREG = 03 ARMRST 01
VREG = 03 ARMRST 01
VREG = 03 ARMRST 00
Saved ./data/dc_nvmem.bin as nvmem
```