### PR TITLE
Linux/Context: Store uctx, not mctx. mctx sometimes misses the float regs

### DIFF
--- a/libswirl/linux/context.cpp
+++ b/libswirl/linux/context.cpp
@@ -18,14 +18,14 @@
 
 //////
 
-#define UCTX(p) (((ucontext_t *)(segfault_ctx))->uc_mcontext p)
+#define UCTX(p) (((ucontext_t *)(segfault_ctx)) p)
 
 #if HOST_OS == OS_DARWIN
-	#define UCTX_type mcontext_t
+	#define UCTX_type ucontext_t
 	#define UCTX_data (UCTX())
 #else
-	#define UCTX_type mcontext_t
-	#define UCTX_data (&UCTX())
+	#define UCTX_type ucontext_t
+	#define UCTX_data (UCTX())
 #endif
 
 template <typename Ta, typename Tb>
@@ -45,7 +45,7 @@ void segfault_store(void* segfault_ctx) {
 #if !defined(TARGET_NO_EXCEPTIONS)
 	memcpy(&segfault_copy, UCTX_data, sizeof(segfault_copy));
 
-	fault_printf("sgctx stored, %d pc: %p\n", sizeof(segfault_copy), segfault_copy.gregs[REG_RIP]);
+	fault_printf("sgctx stored, %d\n", sizeof(segfault_copy));
 #endif
 }
 
@@ -53,11 +53,11 @@ void segfault_load(void* segfault_ctx) {
 #if !defined(TARGET_NO_EXCEPTIONS)
 	memcpy(UCTX_data, &segfault_copy, sizeof(*UCTX_data));
 
-	fault_printf("sgctx loaded, %d pc: %p\n", sizeof(*UCTX_data), UCTX_data->gregs[REG_RIP]);
+	fault_printf("sgctx loaded, %d\n", sizeof(*UCTX_data));
 #endif
 }
 
-#define MCTX(p) ((*(UCTX_type*)segfault_ctx) p)
+#define MCTX(p) (((UCTX_type*)segfault_ctx)->uc_mcontext p)
 
 void context_segfault_bicopy(rei_host_context_t* reictx, void* segfault_ctx, bool to_segfault) {
 


### PR DESCRIPTION
This fixes #1727 