### PR TITLE
Updated list of libraries required for Linux build and how to include Pulseaudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,15 @@ Building for Linux
 	* libasound2-dev
 	* mesa-common-dev
 	* libgl1-mesa-dev
+	* libudev-dev
+	* libpulse-dev (optional for using Pulseaudio)
 
 - From project root directory:
 ```
 cd reicast/linux
+
+# if you wish to use Pulseaudio, uncomment the following line
+# export USE_PULSEAUDIO=1
 
 make
 ```


### PR DESCRIPTION
Was building Reicast for Linux last night on Ubuntu 18.04 and found these extra dependencies were needed. I also wanted to ensure that Pulseaudio was used, so included the flag for those who want to use it.