### PR TITLE
Vertical scaling support added

### DIFF
--- a/core/rend/gles/gltex.cpp
+++ b/core/rend/gles/gltex.cpp
@@ -474,6 +474,17 @@ typedef map<u64,TextureCacheData>::iterator TexCacheIter;
 
 TextureCacheData *getTextureCacheData(TSP tsp, TCW tcw);
 
+double binaryFractionToDouble(u32 numberIntegerPart, u32 numberFractionalPart, u32 fractionalPartLength)
+{
+	double sum = 0;
+
+	for (u32 i = 1; i <= fractionalPartLength; ++i) {
+		sum += !!(numberFractionalPart & (1 << fractionalPartLength - i)) * pow(.5, i);
+	}
+
+	return numberIntegerPart + sum;
+}
+
 void BindRTT(u32 addy, u32 fbw, u32 fbh, u32 channels, u32 fmt)
 {
 	if (gl.rtt.fbo) glDeleteFramebuffers(1,&gl.rtt.fbo);
@@ -489,6 +500,11 @@ void BindRTT(u32 addy, u32 fbw, u32 fbh, u32 channels, u32 fmt)
 	int fbw2 = 2;
 	while (fbw2 < fbw)
 		fbw2 *= 2;
+
+	if (SCALER_CTL.vscalefactor != 0x0400) {
+		fbh2 = round(fbh2 * binaryFractionToDouble(
+				SCALER_CTL.vscalefactor >> 10, SCALER_CTL.vscalefactor & 0x3FF, 10));
+	}
 
 	if (settings.rend.RenderToTextureUpscale > 1 && !settings.rend.RenderToTextureBuffer)
 	{


### PR DESCRIPTION
I have added vertical scaling support (SCALER_CTL), this fixes the issue e.g. in Crazy Taxi pause screen, where background is not properly aligned (see the red arrow):

![20190210105426](https://user-images.githubusercontent.com/5397997/52533033-3015ee80-2d2e-11e9-8575-053c1dba792d.jpeg)
![20190210011430](https://user-images.githubusercontent.com/5397997/52533034-33a97580-2d2e-11e9-812c-9842c2fb85fa.jpeg)