### PR TITLE
load_gles_symbols: Try dlsym first on android

### DIFF
--- a/reicast/android-studio/reicast/src/main/jni/Android.mk
+++ b/reicast/android-studio/reicast/src/main/jni/Android.mk
@@ -86,7 +86,7 @@ LOCAL_PRELINK_MODULE  := false
 LOCAL_MODULE	:= dc
 LOCAL_DISABLE_FORMAT_STRING_CHECKS=true
 LOCAL_ASFLAGS += -fPIC -fvisibility=hidden
-LOCAL_LDLIBS  += -llog -lEGL -lz -landroid
+LOCAL_LDLIBS  += -llog -lEGL -lz -landroid -ldl
 #-Wl,-Map,./res/raw/syms.mp3
 LOCAL_ARM_MODE	:= arm
 


### PR DESCRIPTION
Fixes init on an old Android 4.2.2 stick I have, still compatible with 9 and 10