### PR TITLE
Remove wglSwapLayerBuffers in favor of SwapBuffers

### DIFF
--- a/libswirl/utils/glinit/wgl/wgl.cpp
+++ b/libswirl/utils/glinit/wgl/wgl.cpp
@@ -173,8 +173,7 @@ bool wgl_Init(void* hwnd, void* hdc)
 
 bool wgl_Swap()
 {
-	wglSwapLayerBuffers(ourWindowHandleToDeviceContext, WGL_SWAP_MAIN_PLANE);
-	//SwapBuffers(ourWindowHandleToDeviceContext);
+	SwapBuffers(ourWindowHandleToDeviceContext);
 	return true;
 }
 


### PR DESCRIPTION
The change affects Windows graphics context management: the former function is relatively obscure and causes stuttering at least on Intel Ivy Bridge GT1 iGPU, while the latter is more or less standard, consistent with other platforms and works just fine.

@skmp,
I've finally managed to do the chore and I'm as confused as before. The issue only happens on my Intel Ivy Bridge GT1 iGPU, while the one year older Sandy Bridge GT1 works fine and GeForce GT630M works fine with either or both of functions. So, a driver bug?

I also ran a search on a couple of projects I remember: retroarch, redream, sdl, glfw, fltk, opengl superbible samples and nehe samples all use SwapBuffers and make no mention of the old one, except in systems headers.

All in all, the change seems safe enough to commit without further testing. I haven't left the old one as a comment either: with the function being unknown as it is, the chance of it resurfacing is nil.

The parent issue: https://github.com/reicast/reicast-emulator/issues/1813