### PR TITLE
A few minor Mac changes requested in previous PR

### DIFF
--- a/libswirl/linux/common.cpp
+++ b/libswirl/linux/common.cpp
@@ -56,9 +56,6 @@
 void sigill_handler(int sn, siginfo_t * si, void *segfault_ctx) {
 	
     rei_host_context_t ctx;
-    
-    // TODO: BEN fix this properly
-    //context_from_segfault(&ctx, segfault_ctx);
     context_from_segfault(&ctx);
     
 	unat pc = (unat)ctx.pc;

--- a/libswirl/rend/gles/imgui_impl_opengl3.cpp
+++ b/libswirl/rend/gles/imgui_impl_opengl3.cpp
@@ -134,15 +134,16 @@ void    ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data, bool save_backgr
     // Backup GL state
     glActiveTexture(GL_TEXTURE0);
     bool clip_origin_lower_left = true;
-    
-#if HOST_OS != OS_DARWIN
+
+    // NOTE: This portion is excluded from Mac builds due to the missing symbols glClipControl and GL_CLIP_ORIGIN
+    #if HOST_OS != OS_DARWIN
     if (gl.gl_major >= 4 && glClipControl != NULL)
     {
 		GLenum last_clip_origin = 0; glGetIntegerv(GL_CLIP_ORIGIN, (GLint*)&last_clip_origin); // Support for GL 4.5's glClipControl(GL_UPPER_LEFT)
 		if (last_clip_origin == GL_UPPER_LEFT)
 			clip_origin_lower_left = false;
     }
-#endif
+    #endif
 
     if (save_background)
     {

--- a/reicast/apple/emulator-osx/emulator-osx/AppDelegate.mm
+++ b/reicast/apple/emulator-osx/emulator-osx/AppDelegate.mm
@@ -82,7 +82,7 @@ static void gl_resize();
 
 - (void)setupWindow {
     // Create the OpenGL view and context
-    // TODO: BEN See why background color is red when resizing window tall
+    // TODO: BEN See why background color is red when resizing window tall (it's likely due to default GL framebuffer color)
     _glView = [[EmuGLView alloc] init];
     _glView.delegate = self;
     


### PR DESCRIPTION
I removed the comment regarding the change to the call to `context_from_segfault` and added a comment regarding why a section was ifdef'd out for Mac builds in imgui_impl_opengl.cpp as requested in the review PR comments.