### PR TITLE
Force orientation for Android

### DIFF
--- a/libswirl/android/Android.cpp
+++ b/libswirl/android/Android.cpp
@@ -116,9 +116,10 @@ JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_getControllers(JNIEnv
 
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_setupMic(JNIEnv *env,jobject obj,jobject sip)  __attribute__((visibility("default")));
 
-SETTINGS_ACCESSORS(Nosound, aica.NoSound, jboolean)
-SETTINGS_ACCESSORS(Widescreen, rend.WideScreen, jboolean)
+SETTINGS_ACCESSORS(Nosound, aica.NoSound, jboolean);
+SETTINGS_ACCESSORS(Widescreen, rend.WideScreen, jboolean);
 SETTINGS_ACCESSORS(VirtualGamepadVibration, input.VirtualGamepadVibration, jint);
+SETTINGS_ACCESSORS(ScreenOrientation, rend.ScreenOrientation, jint);
 
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_screenDpi(JNIEnv *env,jobject obj, jint screenDpi)  __attribute__((visibility("default")));
 JNIEXPORT void JNICALL Java_com_reicast_emulator_emu_JNIdc_guiOpenSettings(JNIEnv *env,jobject obj)  __attribute__((visibility("default")));

--- a/libswirl/gui/gui_settings_general.cpp
+++ b/libswirl/gui/gui_settings_general.cpp
@@ -41,6 +41,23 @@ void gui_settings_general()
         ImGui::SameLine();
         gui_ShowHelpMarker("The language as configured in the Dreamcast BIOS");
 
+#ifdef _ANDROID
+		const char *orientation[] = { "Force Portrait", "Force Landscape", "Auto" };
+		if (ImGui::BeginCombo("Orientation", orientation[settings.rend.ScreenOrientation], ImGuiComboFlags_None))
+		{
+			for (int i = 0; i < IM_ARRAYSIZE(orientation); i++)
+			{
+				bool is_selected = settings.rend.ScreenOrientation == i;
+				if (ImGui::Selectable(orientation[i], &is_selected))
+					settings.rend.ScreenOrientation = i;
+				if (is_selected)
+					ImGui::SetItemDefaultFocus();
+			}
+			ImGui::EndCombo();
+		}
+		ImGui::SameLine();
+		gui_ShowHelpMarker("Select type of orientation");
+#endif
 		const char *broadcast[] = { "NTSC", "PAL", "PAL/M", "PAL/N", "Default" };
 		if (ImGui::BeginCombo("Broadcast", broadcast[settings.dreamcast.broadcast], ImGuiComboFlags_None))
 		{

--- a/libswirl/gui/gui_settings_general.cpp
+++ b/libswirl/gui/gui_settings_general.cpp
@@ -42,7 +42,7 @@ void gui_settings_general()
         gui_ShowHelpMarker("The language as configured in the Dreamcast BIOS");
 
 #ifdef _ANDROID
-		const char *orientation[] = { "Force Portrait", "Force Landscape", "Auto" };
+		const char *orientation[] = { "Auto", "Force Portrait", "Force Landscape" };
 		if (ImGui::BeginCombo("Orientation", orientation[settings.rend.ScreenOrientation], ImGuiComboFlags_None))
 		{
 			for (int i = 0; i < IM_ARRAYSIZE(orientation); i++)

--- a/libswirl/libswirl.cpp
+++ b/libswirl/libswirl.cpp
@@ -309,6 +309,7 @@ void InitSettings()
     settings.rend.Fog = true;
     settings.rend.FloatVMUs = false;
     settings.rend.Rotate90 = false;
+    settings.rend.ScreenOrientation = 2; //default is 2 (Auto Rotation)
 
     settings.pvr.ta_skip = 0;
     settings.pvr.backend = "auto";
@@ -405,6 +406,7 @@ void LoadSettings(bool game_specific)
     settings.rend.Fog = cfgLoadBool(config_section, "rend.Fog", settings.rend.Fog);
     settings.rend.FloatVMUs = cfgLoadBool(config_section, "rend.FloatVMUs", settings.rend.FloatVMUs);
     settings.rend.Rotate90 = cfgLoadBool(config_section, "rend.Rotate90", settings.rend.Rotate90);
+    settings.rend.ScreenOrientation = cfgLoadInt(config_section, "rend.ScreenOrientation", settings.rend.ScreenOrientation); //Load Orientation
 
     settings.pvr.ta_skip = cfgLoadInt(config_section, "ta.skip", settings.pvr.ta_skip);
     settings.pvr.backend = cfgLoadStr(config_section, "pvr.backend", settings.pvr.backend.c_str());
@@ -563,6 +565,7 @@ void SaveSettings()
     cfgSaveBool("config", "rend.Fog", settings.rend.Fog);
     cfgSaveBool("config", "rend.FloatVMUs", settings.rend.FloatVMUs);
     cfgSaveBool("config", "rend.Rotate90", settings.rend.Rotate90);
+    cfgSaveInt("config", "rend.ScreenOrientation", settings.rend.ScreenOrientation);
     cfgSaveInt("config", "ta.skip", settings.pvr.ta_skip);
     cfgSaveStr("config", "pvr.backend", settings.pvr.backend.c_str());
 

--- a/libswirl/libswirl.cpp
+++ b/libswirl/libswirl.cpp
@@ -309,7 +309,7 @@ void InitSettings()
     settings.rend.Fog = true;
     settings.rend.FloatVMUs = false;
     settings.rend.Rotate90 = false;
-    settings.rend.ScreenOrientation = 2; //default is 2 (Auto Rotation)
+    settings.rend.ScreenOrientation = 0; //default is 0 (Auto Rotation)
 
     settings.pvr.ta_skip = 0;
     settings.pvr.backend = "auto";

--- a/libswirl/types.h
+++ b/libswirl/types.h
@@ -360,7 +360,6 @@ using namespace std;
 #endif
 
 
-// NOTE: Always inline for macOS builds or it causes duplicate symbol linker errors
 #if DEBUG && HOST_OS != OS_DARWIN
 //force
 #define INLINE
@@ -486,6 +485,7 @@ struct settings_t
 		bool Fog;
 		bool FloatVMUs;
 		bool Rotate90;			// Rotate the screen 90 deg CC
+		int ScreenOrientation;		//Force Screen Orientation value here: 1=Force Portrait, 2=Force Landscape, 3=AutoRotate
 	} rend;
 
 	struct

--- a/libswirl/types.h
+++ b/libswirl/types.h
@@ -359,7 +359,7 @@ using namespace std;
 #define naked __attribute__((naked))
 #endif
 
-
+// NOTE: Always inline for macOS builds or it causes duplicate symbol linker errors
 #if DEBUG && HOST_OS != OS_DARWIN
 //force
 #define INLINE

--- a/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/BaseGLActivity.java
+++ b/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/BaseGLActivity.java
@@ -141,9 +141,9 @@ public abstract class BaseGLActivity extends Activity implements ActivityCompat.
 
     public void setOrientation(){ //forcing orientation, depending on the value of Emulator.screenOrientation
         Log.i("reicast", Integer.toString(Emulator.screenOrientation));
-       if ((Emulator.screenOrientation == 0)){
+       if ((Emulator.screenOrientation == 1)){
            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-       }else if ((Emulator.screenOrientation == 1)){
+       }else if ((Emulator.screenOrientation == 2)){
            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
        }else{
            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);

--- a/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
+++ b/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
@@ -23,6 +23,7 @@ public class Emulator extends Application {
 
     public static boolean nosound = false;
     public static int vibrationDuration = 20;
+    public static int screenOrientation = 2; //Default value is 2
 
     public static int maple_devices[] = {
             MDT_None,
@@ -44,6 +45,7 @@ public class Emulator extends Application {
     public void getConfigurationPrefs() {
         Emulator.nosound = JNIdc.getNosound();
         Emulator.vibrationDuration = JNIdc.getVirtualGamepadVibration();
+        Emulator.screenOrientation = JNIdc.getScreenOrientation(); //Loading screenOrientation
         JNIdc.getControllers(maple_devices, maple_expansion_devices);
     }
 
@@ -53,10 +55,12 @@ public class Emulator extends Application {
      */
     public void SaveAndroidSettings(String homeDirectory)
     {
+
         Log.i("reicast", "SaveAndroidSettings: saving preferences");
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         Emulator.nosound = JNIdc.getNosound();
         Emulator.vibrationDuration = JNIdc.getVirtualGamepadVibration();
+        Emulator.screenOrientation = JNIdc.getScreenOrientation();
         JNIdc.getControllers(maple_devices, maple_expansion_devices);
 
         prefs.edit()
@@ -67,6 +71,8 @@ public class Emulator extends Application {
         if (micPluggedIn() && currentActivity instanceof BaseGLActivity) {
             ((BaseGLActivity)currentActivity).requestRecordAudioPermission();
         }
+        currentActivity.setOrientation(); //As the settings are saved, setOrientation sets the new Orientation of the device
+
     }
 
     public void LaunchFromUrl(String url) {

--- a/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
+++ b/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/Emulator.java
@@ -23,7 +23,7 @@ public class Emulator extends Application {
 
     public static boolean nosound = false;
     public static int vibrationDuration = 20;
-    public static int screenOrientation = 2; //Default value is 2
+    public static int screenOrientation = 0; //Default value is 0
 
     public static int maple_devices[] = {
             MDT_None,

--- a/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
+++ b/reicast/android-studio/reicast/src/main/java/com/reicast/emulator/emu/JNIdc.java
@@ -29,6 +29,7 @@ public final class JNIdc
 
 	public static native void setupMic(SipEmulator sip);
 	public static native boolean getNosound();
+	public static native int getScreenOrientation(); //Using SETTINGS_ACCESSORS to get the value of ScreenOrientation
 
 	public static native int getVirtualGamepadVibration();
 


### PR DESCRIPTION
As requested here #1795. This feature can be accessed by settings->general at any time, and the changes are applied instantly (no need for restart). There are three options there (force Portrait, force Landscape and Auto). Everything works fine on my Android device. If there is any issue, please let me know.  :) 