### PR TITLE
fix(win32): also check height when saving window dimensions

### DIFF
--- a/libswirl/windows/winmain.cpp
+++ b/libswirl/windows/winmain.cpp
@@ -798,7 +798,7 @@ int CALLBACK WinMain(HINSTANCE hInstance,HINSTANCE hPrevInstance,LPSTR lpCmdLine
 #endif
 	SetUnhandledExceptionFilter(0);
 	cfgSaveBool("windows", "maximized", window_maximized);
-	if (!window_maximized && screen_width != 0 && screen_width != 0)
+	if (!window_maximized && screen_width != 0 && screen_height != 0)
 	{
 		cfgSaveInt("windows", "width", screen_width);
 		cfgSaveInt("windows", "height", screen_height);


### PR DESCRIPTION
Fixed small typo, `screen_width` was being checked twice instead of also checking `screen_height` when storing the window dimensions in the config file.