### PR TITLE
Fixed virtual serial when nothing is connected

### DIFF
--- a/libswirl/hw/sh4/modules/scif.cpp
+++ b/libswirl/hw/sh4/modules/scif.cpp
@@ -48,7 +48,7 @@ void SerialWriteData(u8 data) {
 		}
 #if FEAT_HAS_SERIAL_TTY
 		if (pty_master != -1) {
-			while(write(pty_master, &data, 1) != 1)
+			while(write(pty_master, &data, 1) != 1 && errno != EAGAIN)
 				printf("SERIAL: PTY write failed, %s\n", strerror(errno));
 		}
 #endif

--- a/libswirl/linux/common.cpp
+++ b/libswirl/linux/common.cpp
@@ -346,7 +346,7 @@ void common_linux_setup()
 }
 
 #if FEAT_HAS_SERIAL_TTY
-int pty_master;
+int pty_master = -1;
 bool common_serial_pty_setup() {
     bool cleanup_pty_symlink = false;
     if (settings.debug.VirtualSerialPort) {


### PR DESCRIPTION
When nothing is connected to the tty file, the write buffer gets filled (which is expected), so we needed to add a check for `errno != EAGAIN`. Also @skmp noticed that `pty_master` was not being initialized to -1 when virtual serial was turned off, also causing problems.

Tested working with previously 100% non-working CDIs, and tested virtual tty using screen. Also tested again with dcload-serial, which was working before anyway since it was reading from the tty.