### PR TITLE
Fixed Werker CI builds by pinning to Ubuntu 18.04

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: ubuntu
+box: ubuntu:18.04
 
 build:
     steps:


### PR DESCRIPTION
Before it was just specifying "ubuntu" as the docker image to build with, which is the same as using "ubuntu:latest". A few weeks ago, Ubuntu updated their "latest" tag to point to the new 20.04 image rather than the previous 18.04 LTS. This caused a minor change in the installation of the tzdata package (and possibly other stuff).

This commit just pins the docker image to Ubuntu 18.04 so it won't randomly break out from under us any time Ubuntu changes their "latest" image tag.

Since Github Actions CI Workflow is 100% free for all platforms and is very powerful, I think we should switch off of all of these other CI services anyway and just use that so we don't have to juggle all of these CI configs. So for now I this is the simplest fix to get commits and PRs passing CI again, rather than trying to see what other minor tweaks to the CI config are needed to work with Ubuntu 20.04. Later if/when we switch to just using Github Actions we can make whatever tweaks we need and even specifically test on various Linux distributions and versions. 