### PR TITLE
Fixed crash when updating controller settings

### DIFF
--- a/libswirl/hw/maple/maple_if.cpp
+++ b/libswirl/hw/maple/maple_if.cpp
@@ -308,10 +308,14 @@ MMIODevice* Create_MapleDevice(SystemBus* sb, ASIC* asic) {
 
 void maple_vblank()
 {
+    if (!sh4_cpu) return;
+    
 	sh4_cpu->GetA0H<MapleDevice>(A0H_MAPLE)->OnVblank();
 }
 
 void maple_ReconnectDevices()
 {
+    if (!sh4_cpu) return;
+    
 	sh4_cpu->GetA0H<MapleDevice>(A0H_MAPLE)->ReconnectDevices();
 }


### PR DESCRIPTION
This was happening any time the emulator wasn't running yet. For example after first launching Reicast then setting up your controllers. From what I can tell, it would happen on all platforms, not just MacOS, though I've confirmed it's fixed there.

The actual fix is just the null check in the `maple_ReconnectDevices()` function. I added a similar null check in `maple_vblank()` just to be safe.