### PR TITLE
Danb91/support keyboard analog stick

### DIFF
--- a/libswirl/gui/gui_settings_controls.cpp
+++ b/libswirl/gui/gui_settings_controls.cpp
@@ -74,10 +74,10 @@ static const char *maple_expansion_device_name(MapleDeviceType type)
 }
 
 const char *maple_ports[] = { "None", "A", "B", "C", "D" };
-const DreamcastKey button_keys[] = { DC_BTN_START, DC_BTN_A, DC_BTN_B, DC_BTN_X, DC_BTN_Y, DC_DPAD_UP, DC_DPAD_DOWN, DC_DPAD_LEFT, DC_DPAD_RIGHT,
+const DreamcastKey button_keys[] = { EMU_BTN_STICK_UP, EMU_BTN_STICK_DOWN, EMU_BTN_STICK_LEFT, EMU_BTN_STICK_RIGHT, DC_BTN_START, DC_BTN_A, DC_BTN_B, DC_BTN_X, DC_BTN_Y, DC_DPAD_UP, DC_DPAD_DOWN, DC_DPAD_LEFT, DC_DPAD_RIGHT,
 		EMU_BTN_MENU, EMU_BTN_ESCAPE, EMU_BTN_TRIGGER_LEFT, EMU_BTN_TRIGGER_RIGHT,
 		DC_BTN_C, DC_BTN_D, DC_BTN_Z, DC_DPAD2_UP, DC_DPAD2_DOWN, DC_DPAD2_LEFT, DC_DPAD2_RIGHT };
-const char *button_names[] = { "Start", "A", "B", "X", "Y", "DPad Up", "DPad Down", "DPad Left", "DPad Right",
+const char *button_names[] = { "Stick Up", "Stick Down", "Stick Left", "Stick Right", "Start", "A", "B", "X", "Y", "DPad Up", "DPad Down", "DPad Left", "DPad Right",
 		"Menu", "Exit", "Left Trigger", "Right Trigger",
 		"C", "D", "Z", "Right Dpad Up", "Right DPad Down", "Right DPad Left", "Right DPad Right" };
 const DreamcastKey axis_keys[] = { DC_AXIS_X, DC_AXIS_Y, DC_AXIS_LT, DC_AXIS_RT, EMU_AXIS_DPAD1_X, EMU_AXIS_DPAD1_Y, EMU_AXIS_DPAD2_X, EMU_AXIS_DPAD2_Y };

--- a/libswirl/input/gamepad.h
+++ b/libswirl/input/gamepad.h
@@ -33,6 +33,10 @@ enum DreamcastKey
 	EMU_BTN_TRIGGER_LEFT	= 1 << 17,
 	EMU_BTN_TRIGGER_RIGHT	= 1 << 18,
 	EMU_BTN_MENU			= 1 << 19,
+    EMU_BTN_STICK_LEFT     = 1 << 20,
+    EMU_BTN_STICK_RIGHT    = 1 << 21,
+    EMU_BTN_STICK_UP       = 1 << 22,
+    EMU_BTN_STICK_DOWN     = 1 << 23,
 
 	// Real axes
 	DC_AXIS_LT		 = 0x10000,

--- a/libswirl/input/gamepad_device.cpp
+++ b/libswirl/input/gamepad_device.cpp
@@ -99,6 +99,18 @@ bool GamepadDevice::gamepad_btn_input(u32 code, bool pressed)
 		case EMU_BTN_TRIGGER_RIGHT:
 			rt[_maple_port] = pressed ? 255 : 0;
 			break;
+        case EMU_BTN_STICK_LEFT:
+            joyx[_maple_port] = pressed ? -128 : 0;
+            break;
+        case EMU_BTN_STICK_RIGHT:
+            joyx[_maple_port] = pressed ? 127 : 0;
+            break;
+        case EMU_BTN_STICK_UP:
+            joyy[_maple_port] = pressed ? -128 : 0;
+            break;
+        case EMU_BTN_STICK_DOWN:
+            joyy[_maple_port] = pressed ? 127 : 0;
+            break;
 		default:
 			return false;
 		}

--- a/libswirl/linux-dist/emscripten.cpp
+++ b/libswirl/linux-dist/emscripten.cpp
@@ -31,6 +31,12 @@ public:
 		set_button(EMU_BTN_TRIGGER_LEFT, 70);
 		set_button(EMU_BTN_TRIGGER_RIGHT, 86);
 		set_button(EMU_BTN_MENU, 9);
+        
+                //TODO:
+        //        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
+        //        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
+        //        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
+        //        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
 
 		dirty = false;
 	}

--- a/libswirl/linux-dist/x11.h
+++ b/libswirl/linux-dist/x11.h
@@ -75,6 +75,8 @@ const int KEY_RSHIFT = 62;
 const int KEY_LCTRL = 37;
 const int KEY_RCTRL = 105;
 const int KEY_LALT = 64;
+const int KEY_SEMICOLON = 47;
+const int KEY_QUOTE = 48;
 
 const int KEY_F1	=  67;
 const int KEY_F2	=  68;

--- a/libswirl/linux-dist/x11_keyboard.h
+++ b/libswirl/linux-dist/x11_keyboard.h
@@ -177,6 +177,12 @@ public:
 		set_button(EMU_BTN_TRIGGER_RIGHT, KEY_V);
 		set_button(EMU_BTN_MENU, KEY_TAB);
 
+        //TODO:
+//        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
+//        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
+//        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
+//        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
+
 		dirty = false;
 	}
 };

--- a/libswirl/linux-dist/x11_keyboard.h
+++ b/libswirl/linux-dist/x11_keyboard.h
@@ -176,12 +176,10 @@ public:
 		set_button(EMU_BTN_TRIGGER_LEFT, KEY_F);
 		set_button(EMU_BTN_TRIGGER_RIGHT, KEY_V);
 		set_button(EMU_BTN_MENU, KEY_TAB);
-
-        //TODO:
-//        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
-//        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
-//        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
-//        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
+        set_button(EMU_BTN_STICK_UP, KEY_P);
+        set_button(EMU_BTN_STICK_DOWN, KEY_SEMICOLON);
+        set_button(EMU_BTN_STICK_LEFT, KEY_L);
+        set_button(EMU_BTN_STICK_RIGHT, KEY_QUOTE);
 
 		dirty = false;
 	}

--- a/libswirl/windows/xinput_gamepad.h
+++ b/libswirl/windows/xinput_gamepad.h
@@ -229,12 +229,10 @@ public:
 		set_button(EMU_BTN_TRIGGER_LEFT, 'F');
 		set_button(EMU_BTN_TRIGGER_RIGHT, 'V');
 		set_button(EMU_BTN_MENU, VK_TAB);
-        
-                //TODO:
-        //        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
-        //        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
-        //        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
-        //        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
+        set_button(EMU_BTN_STICK_UP, 'P');
+        set_button(EMU_BTN_STICK_DOWN, VK_OEM_1); //; on US keyboard
+        set_button(EMU_BTN_STICK_LEFT, 'L');
+        set_button(EMU_BTN_STICK_RIGHT, VK_OEM_7); //' on US keyboard
 
 		dirty = false;
 	}

--- a/libswirl/windows/xinput_gamepad.h
+++ b/libswirl/windows/xinput_gamepad.h
@@ -229,6 +229,12 @@ public:
 		set_button(EMU_BTN_TRIGGER_LEFT, 'F');
 		set_button(EMU_BTN_TRIGGER_RIGHT, 'V');
 		set_button(EMU_BTN_MENU, VK_TAB);
+        
+                //TODO:
+        //        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
+        //        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
+        //        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
+        //        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
 
 		dirty = false;
 	}

--- a/reicast/apple/emulator-osx/emulator-osx/OSXGamepadDevice.h
+++ b/reicast/apple/emulator-osx/emulator-osx/OSXGamepadDevice.h
@@ -11,20 +11,26 @@
 class KbInputMapping : public InputMapping {
 public:
 	KbInputMapping() {
-		name = "OSX Keyboard";
-		set_button(DC_BTN_A, kVK_ANSI_X);
-		set_button(DC_BTN_B, kVK_ANSI_C);
-		set_button(DC_BTN_X, kVK_ANSI_S);
-		set_button(DC_BTN_Y, kVK_ANSI_D);
+        name = "OSX Keyboard";
+        set_button(DC_BTN_A, kVK_ANSI_X);
+        set_button(DC_BTN_B, kVK_ANSI_C);
+        set_button(DC_BTN_X, kVK_ANSI_S);
+        set_button(DC_BTN_Y, kVK_ANSI_D);
+
 		set_button(DC_DPAD_UP, kVK_UpArrow);
 		set_button(DC_DPAD_DOWN, kVK_DownArrow);
 		set_button(DC_DPAD_LEFT, kVK_LeftArrow);
 		set_button(DC_DPAD_RIGHT, kVK_RightArrow);
 		set_button(DC_BTN_START, kVK_Return);
-		set_button(EMU_BTN_TRIGGER_LEFT, kVK_ANSI_F);
-		set_button(EMU_BTN_TRIGGER_RIGHT, kVK_ANSI_V);
+        set_button(EMU_BTN_TRIGGER_LEFT, kVK_ANSI_F);
+        set_button(EMU_BTN_TRIGGER_RIGHT, kVK_ANSI_V);
 		set_button(EMU_BTN_MENU, kVK_Tab);
 		
+        set_button(EMU_BTN_STICK_UP, kVK_ANSI_P);
+        set_button(EMU_BTN_STICK_DOWN, kVK_ANSI_Semicolon);
+        set_button(EMU_BTN_STICK_LEFT, kVK_ANSI_L);
+        set_button(EMU_BTN_STICK_RIGHT, kVK_ANSI_Quote);
+        
 		dirty = false;
 	}
 };


### PR DESCRIPTION
Support for using the keyboard keys the analog stick on the Dreamcast controller.  This PR adds support for any platform Reicast is on, but only adds default values for Mac/Windows/Linux. 

To keep things consistent with the other default keyboard controls, the default Up, Down, Left, Right are mapped to **P**, **;**, **L** and **'**, respectively.   Of course, this can be remapped to any key the user desires.