### PR TITLE
Add support for newer Raspberry Pi 4 with 8 GB RAM, BCM2711

### DIFF
--- a/reicast/linux/detect-platform.make
+++ b/reicast/linux/detect-platform.make
@@ -20,6 +20,8 @@ ifeq (,$(platform))
             platform = rpi2
         else ifneq (,$(findstring BCM2835,$(HARDWARE)))
             platform = rpi4
+        else ifneq (,$(findstring BCM2711,$(HARDWARE)))
+            platform = rpi4
         else ifneq (,$(findstring AM33XX,$(HARDWARE)))
             platform = beagle
         else ifneq (,$(findstring Pandora,$(HARDWARE)))


### PR DESCRIPTION
Add support for newer Raspberry Pi 4 with 8 GB RAM, the BCM2711.

I have only tested building reicast under Raspbian Buster but it works fine with this patch.