### PR TITLE
Fixed a compile-time error when using MSVC build tools.

### DIFF
--- a/libswirl/hw/pvr/Renderer_if.cpp
+++ b/libswirl/hw/pvr/Renderer_if.cpp
@@ -21,7 +21,7 @@
 
 #include <memory>
 #include <atomic>
-#Include <iterator>
+#include <iterator>
 
 #if FEAT_HAS_NIXPROF
 #include "profiler/profiler.h"

--- a/libswirl/hw/pvr/Renderer_if.cpp
+++ b/libswirl/hw/pvr/Renderer_if.cpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <atomic>
+#Include <iterator>
 
 #if FEAT_HAS_NIXPROF
 #include "profiler/profiler.h"


### PR DESCRIPTION
This fixes a problem when compiling Reicast using the Visual Studio Build Tools 2019 on Windows.

When compiling Reicast using the command-line build tools, the compiler issues an error when it reaches Renderer_if.cpp at line 556,  'back_inserter: identifier not found'. This PR adds <iterator> to the #include list at the top, allowing the file to compile correctly and the build to complete successfully.

Any and all feedback is much appreciated.